### PR TITLE
callEndpoint: support noFlatten, returnRaw, saveRaw, saveParsed options

### DIFF
--- a/API.md
+++ b/API.md
@@ -90,7 +90,12 @@ transformed and validated according to the rules defined in lib/endpoints
 **Parameters**
 
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of MWS API function to call
--   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** named hash object of the parameters to pass to the API
+-   `callOptions` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** named hash object of the parameters to pass to the API (optional, default `{}`)
+-   `opt` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** options for callEndpoint (optional, default `{}`)
+    -   `opt.noFlatten` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** do not flatten results
+    -   `opt.returnRaw` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** return only the raw data (may or may not be flattened)
+    -   `opt.saveRaw` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** filename to save raw data to (may or may not be flattened)
+    -   `opt.saveParsed` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** filename to save final parsed data to (not compatible with returnRaw, since parsing won't happen)
 
 Returns **any** Results of the call to MWS
 
@@ -276,6 +281,20 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 **Parameters**
 
 -   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
 -   `subCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The subcondition of the item (New, Mint, Very Good, Good, Acceptable, Poor, Club, OEM, Warranty, Refurbished Warranty, Refurbished, Open Box, or Other)
 -   `sellerFeedbackRating` **SellerFeedbackRating** Information about the seller's feedback
 -   `shippingTime` **DetailedShippingTime** Maximum time within which the item will likely be shipped
@@ -286,20 +305,6 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 -   `isFulfilledByAmazon` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if FBA, False if not
 -   `isBuyBoxWinner` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if offer has buy box, False if not
 -   `isFeaturedMerchant` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if seller is eligible for Buy Box, False if not
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ## reformatLowestPrice
 

--- a/API.md
+++ b/API.md
@@ -22,8 +22,8 @@
 -   [listOrders](#listorders)
 -   [listFinancialEvents](#listfinancialevents)
 -   [listInventorySupply](#listinventorysupply)
--   [Product](#product)
 -   [getMatchingProductForId](#getmatchingproductforid)
+-   [Product](#product)
 -   [reformatOfferCount](#reformatoffercount)
 -   [reformatOffer](#reformatoffer)
 -   [reformatOffer](#reformatoffer-1)
@@ -63,14 +63,16 @@ holds the mws-simple reference after init() is called
 ## init
 
 Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively
 
 **Parameters**
 
 -   `config` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Contains your MWS Access Keys/Tokens and options to configure the API (optional, default `{}`)
     -   `config.region` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** One of the Amazon regions as specified in <https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html> (optional, default `'NA'`)
-    -   `config.accessKeyId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Access Key
-    -   `config.secretAccessKey` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Secret Access Key
-    -   `config.merchantId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Merchant ID
+    -   `config.accessKeyId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Access Key (optional, default `process.env.MWS_ACCESS_KEY`)
+    -   `config.secretAccessKey` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Secret Access Key (optional, default `process.env.MWS_SECRET_ACCESS_KEY`)
+    -   `config.merchantId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Your MWS Merchant ID (optional, default `process.env.MWS_MERCHANT_ID`)
     -   `config.authToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** If making a call for a third party account, the Auth Token provided
                                   for the third party account
     -   `config.host` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Set MWS host server name, see <https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html> (optional, default `'mws.amazonservices.com'`)
@@ -147,6 +149,15 @@ Returns **{markets: [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScr
 
 ## listOrderItems
 
+**Parameters**
+
+-   `AmazonOrderId`  
+-   `orderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Amazon Order ID
+-   `nextToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
+-   `orderItems` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Array of all the items in the order
+
+## listOrderItems
+
 Returns order items based on the AmazonOrderId that you specify.
 
 If you've pulled a list of orders using @see [ListOrders](ListOrders), or have order identifiers
@@ -166,15 +177,6 @@ ShippingDiscount
 -   `AmazonOrderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 3-7-7 Amazon Order ID formatted string
 
 Returns **OrderItemList** 
-
-## listOrderItems
-
-**Parameters**
-
--   `AmazonOrderId`  
--   `orderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Amazon Order ID
--   `nextToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
--   `orderItems` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Array of all the items in the order
 
 ## listOrders
 
@@ -231,14 +233,6 @@ Return information about the availability of a seller's FBA inventory
 
 Returns **{nextToken: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), supplyList: [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>}** 
 
-## Product
-
-Product Information. See official schema for details.
-<http://g-ecx.images-amazon.com/images/G/01/mwsportal/doc/en_US/products/default.xsd> and
-<http://g-ecx.images-amazon.com/images/G/01/mwsportal/doc/en_US/products/ProductsAPI_Response.xsd>
-
-Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
 ## getMatchingProductForId
 
 Returns a list of products and their attributes, based on a list of ASIN, GCID, SellerSKU, UPC,
@@ -253,6 +247,14 @@ EAN, ISBN, or JAN values
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Product](#product)>** 
 
+## Product
+
+Product Information. See official schema for details.
+<http://g-ecx.images-amazon.com/images/G/01/mwsportal/doc/en_US/products/default.xsd> and
+<http://g-ecx.images-amazon.com/images/G/01/mwsportal/doc/en_US/products/ProductsAPI_Response.xsd>
+
+Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
 ## reformatOfferCount
 
 **Parameters**
@@ -261,34 +263,6 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 -   `count` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `condition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `fulfillmentChannel` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ## reformatOffer
 
@@ -305,6 +279,34 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 -   `isFulfilledByAmazon` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if FBA, False if not
 -   `isBuyBoxWinner` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if offer has buy box, False if not
 -   `isFeaturedMerchant` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if seller is eligible for Buy Box, False if not
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ## reformatLowestPrice
 
@@ -340,17 +342,6 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 
 ## getLowestPricedOffersForASIN
 
-**Parameters**
-
--   `options`  
--   `asin` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** asin returned by request
--   `marketplace` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** marketplace asin is in
--   `itemCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** condition of item requested
--   `summary` **OfferSummary** \-
--   `offers` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Offers>** list of offers
-
-## getLowestPricedOffersForASIN
-
 getLowestPricedOffersForASIN
 
 Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
@@ -364,6 +355,17 @@ Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
 
 Returns **LowestPricedOffers** 
 
+## getLowestPricedOffersForASIN
+
+**Parameters**
+
+-   `options`  
+-   `asin` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** asin returned by request
+-   `marketplace` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** marketplace asin is in
+-   `itemCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** condition of item requested
+-   `summary` **OfferSummary** \-
+-   `offers` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Offers>** list of offers
+
 ## writeFile
 
 Promisified version of fs.writeFile
@@ -375,19 +377,6 @@ This is better than using writeFileSync. Trust me. :-)
 
 -   `fileName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** path/filename to write to
 -   `contents` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Buffer](https://nodejs.org/api/buffer.html))** what to write to file
-
-## requestReport
-
-**Parameters**
-
--   `options`  
--   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
--   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
--   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date Ending period
--   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to fetch the report when ready
--   `SubmittedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date request was submitted
--   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date report begins at
 
 ## requestReport
 
@@ -405,20 +394,18 @@ Many optional parameters may be required by MWS! Read [ReportType](https://docs.
 
 Returns **ReportRequestInfo** 
 
-## getReportRequestList
+## requestReport
 
 **Parameters**
 
--   `options`   (optional, default `{}`)
+-   `options`  
 -   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
 -   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
--   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
+-   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date Ending period
 -   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
--   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
--   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
--   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
--   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
+-   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to fetch the report when ready
+-   `SubmittedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date request was submitted
+-   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date report begins at
 
 ## getReportRequestList
 
@@ -437,6 +424,21 @@ has been processed.
 -   `RequestedToDate` **[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)** Newest date to search for (optional, default `Now`)
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;GetReportRequestListResult>** 
+
+## getReportRequestList
+
+**Parameters**
+
+-   `options`   (optional, default `{}`)
+-   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
+-   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
+-   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
+-   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
+-   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
+-   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
+-   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
+-   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
+-   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
 
 ## getReport
 

--- a/docs/file/lib/callEndpoint.js.html
+++ b/docs/file/lib/callEndpoint.js.html
@@ -97,12 +97,14 @@ let mws = null;
 
 /**
  * Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+ * If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+ * the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively
  *
  * @public
  * @param {object} config Contains your MWS Access Keys/Tokens and options to configure the API
- * @param {string} config.accessKeyId Your MWS Access Key
- * @param {string} config.secretAccessKey Your MWS Secret Access Key
- * @param {string} config.merchantId Your MWS Merchant ID
+ * @param {string} [config.accessKeyId=process.env.MWS_ACCESS_KEY] Your MWS Access Key
+ * @param {string} [config.secretAccessKey=process.env.MWS_SECRET_ACCESS_KEY] Your MWS Secret Access Key
+ * @param {string} [config.merchantId=process.env.MWS_MERCHANT_ID] Your MWS Merchant ID
  * @param {string} [config.authToken] If making a call for a third party account, the Auth Token provided
  *                           for the third party account
  * @param {string} [config.region=&apos;NA&apos;] One of the Amazon regions as specified in https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html
@@ -110,12 +112,13 @@ let mws = null;
  * @param {number} [config.port=443] Set MWS host port
  * @returns {mws-simple} - The mws-simple instance used to communicate with the API
  */
+
 const init = ({
     region = &apos;NA&apos;,
     // marketplace = &apos;US&apos;, // TODO: maybe someday we will want to keep track of a &apos;default&apos; marketplace.
-    accessKeyId,
-    secretAccessKey,
-    merchantId,
+    accessKeyId = process.env.MWS_ACCESS_KEY,
+    secretAccessKey = process.env.MWS_SECRET_ACCESS_KEY,
+    merchantId = process.env.MWS_MERCHANT_ID,
     authToken,
     host,
     port,

--- a/docs/file/lib/callEndpoint.js.html
+++ b/docs/file/lib/callEndpoint.js.html
@@ -82,6 +82,7 @@
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const MWS = require(&apos;mws-simple&apos;);
 const { MWS_ENDPOINTS } = require(&apos;./constants&apos;);
 const sleep = require(&apos;./sleep&apos;);
+const fs = require(&apos;fs&apos;);
 
 /*
  * TODO: split the &quot;init&quot; function out of the &quot;callEndpoint&quot; file, difficulty: callEndpoint
@@ -171,17 +172,17 @@ const endpoints = {
  * @async
  * @private
  * @param {any} requestData
+ * @param {object} [opt] - options
+ * @param {boolean} [opt.noFlatten] - do not run flattenResult on the output
  */
-const requestPromise = requestData =&gt;
+const requestPromise = (requestData, opt = {}) =&gt;
     new Promise((resolve, reject) =&gt; {
         // eslint-disable-next-line global-require
         mws.request(requestData, (err, result) =&gt; {
             if (err) {
-                console.warn(&apos;**** requestPromise error hit&apos;);
                 reject(err);
             } else {
-                const flatResult = flattenResult(result);
-                resolve(flatResult);
+                resolve(opt.noFlatten ? result : flattenResult(result));
             }
         });
     });
@@ -193,17 +194,22 @@ const requestPromise = requestData =&gt;
  * @async
  * @public
  * @param {string} name - name of MWS API function to call
- * @param {object} options - named hash object of the parameters to pass to the API
+ * @param {object} [callOptions] - named hash object of the parameters to pass to the API
+ * @param {object} [opt] - options for callEndpoint
+ * @param {boolean} [opt.noFlatten] - do not flatten results
+ * @param {boolean} [opt.returnRaw] - return only the raw data (may or may not be flattened)
+ * @param {string} [opt.saveRaw] - filename to save raw data to (may or may not be flattened)
+ * @param {string} [opt.saveParsed] - filename to save final parsed data to (not compatible with returnRaw, since parsing won&apos;t happen)
  * @returns {any} - Results of the call to MWS
  */
-const callEndpoint = async (name, options) =&gt; {
+const callEndpoint = async (name, callOptions = {}, opt = {}) =&gt; {
     const endpoint = endpoints[name];
     if (!endpoint) {
         throw new Error(&apos;No endpoint name supplied to callEndpoint&apos;);
     }
 
     const newOptions = endpoint.params ?
-        validateAndTransformParameters(endpoint.params, options) : options;
+        validateAndTransformParameters(endpoint.params, callOptions) : callOptions;
 
     const queryOptions = {
         ...newOptions,
@@ -217,12 +223,21 @@ const callEndpoint = async (name, options) =&gt; {
     };
 
     try {
-        const result = await requestPromise(params);
+        const result = await requestPromise(params, { noFlatten: opt.noFlatten });
+        if (opt.saveRaw) {
+            fs.writeFileSync(opt.saveRaw, JSON.stringify(result));
+        }
+        if (opt.returnRaw) {
+            return result;
+        }
         // TODO: add an option that will store the raw data, and a separate option to store the parsed
         // data, to file
         // const fs = require(&apos;fs&apos;);
         // fs.appendFile(`${name}-out.json`, JSON.stringify(result));
         const digResult = digResponseResult(name, result);
+        if (opt.saveParsed) {
+            fs.writeFileSync(opt.saveParsed, JSON.stringify(digResult));
+        }
         return digResult;
     } catch (err) {
         if (err.code === 503) {
@@ -250,7 +265,7 @@ const callEndpoint = async (name, options) =&gt; {
             }
             console.warn(`***** trying again in ${ms}ms`);
             await sleep(ms + 100);
-            return callEndpoint(name, options);
+            return callEndpoint(name, callOptions, opt);
         }
         throw err;
     }

--- a/docs/file/lib/list-financial-events.js.html
+++ b/docs/file/lib/list-financial-events.js.html
@@ -81,6 +81,10 @@
 <div class="content" data-ice="content"><h1 data-ice="title">lib/list-financial-events.js</h1>
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const { callEndpoint } = require(&apos;./callEndpoint&apos;);
 
+// TODO: probably needs to handle nextToken
+
+// const arr = obj =&gt; (obj.length ? obj : [obj]);
+
 /**
  * https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html
  *

--- a/docs/function/index.html
+++ b/docs/function/index.html
@@ -97,7 +97,7 @@
           
           <span data-ice="async">async</span>
           
-          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, options: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, callOptions: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>, opt: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
         </p>
       </div>
       <div>
@@ -569,15 +569,15 @@ Many optional parameters may be required by MWS! Read <a href="https://docs.deve
     
     <span data-ice="async">async</span>
     
-    <span class="code" data-ice="name">callEndpoint</span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, options: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
+    <span class="code" data-ice="name">callEndpoint</span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, callOptions: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>, opt: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber118">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber124">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber118">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber124">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Call a known endpoint at MWS, returning the raw data from the function. Parameters are
@@ -602,10 +602,45 @@ transformed and validated according to the rules defined in lib/endpoints</p>
 </td>
     </tr>
 <tr data-ice="property" data-depth="0">
-      <td data-ice="name" class="code" data-depth="0">options</td>
+      <td data-ice="name" class="code" data-depth="0">callOptions</td>
       <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span></td>
-      <td data-ice="appendix"></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
       <td data-ice="description"><p>named hash object of the parameters to pass to the API</p>
+</td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">opt</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
+      <td data-ice="description"><p>options for callEndpoint</p>
+</td>
+    </tr>
+<tr data-ice="property" data-depth="1">
+      <td data-ice="name" class="code" data-depth="1">opt.noFlatten</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></span></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
+      <td data-ice="description"><p>do not flatten results</p>
+</td>
+    </tr>
+<tr data-ice="property" data-depth="1">
+      <td data-ice="name" class="code" data-depth="1">opt.returnRaw</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></span></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
+      <td data-ice="description"><p>return only the raw data (may or may not be flattened)</p>
+</td>
+    </tr>
+<tr data-ice="property" data-depth="1">
+      <td data-ice="name" class="code" data-depth="1">opt.saveRaw</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
+      <td data-ice="description"><p>filename to save raw data to (may or may not be flattened)</p>
+</td>
+    </tr>
+<tr data-ice="property" data-depth="1">
+      <td data-ice="name" class="code" data-depth="1">opt.saveParsed</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span></td>
+      <td data-ice="appendix"><ul><li>optional</li></ul></td>
+      <td data-ice="description"><p>filename to save final parsed data to (not compatible with returnRaw, since parsing won&apos;t happen)</p>
 </td>
     </tr>
 </tbody>
@@ -1333,11 +1368,11 @@ has been processed.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber31">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber32">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber31">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber32">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port</p>
@@ -1460,11 +1495,11 @@ has been processed.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/list-financial-events.js.html#lineNumber14">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/list-financial-events.js.html#lineNumber18">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {listFinancialEvents} from &apos;<span><a href="file/lib/list-financial-events.js.html#lineNumber14">mws-advanced/lib/list-financial-events.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {listFinancialEvents} from &apos;<span><a href="file/lib/list-financial-events.js.html#lineNumber18">mws-advanced/lib/list-financial-events.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p><a href="https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html">https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html</a></p>

--- a/docs/function/index.html
+++ b/docs/function/index.html
@@ -369,7 +369,9 @@ has been processed.</p>
       <div>
         
         
-        <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port</p>
+        <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively</p>
 </div>
       </div>
     </td>
@@ -573,11 +575,11 @@ Many optional parameters may be required by MWS! Read <a href="https://docs.deve
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber124">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber127">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber124">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber127">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Call a known endpoint at MWS, returning the raw data from the function. Parameters are
@@ -1368,14 +1370,16 @@ has been processed.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber32">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber35">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber32">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber35">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
-  <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port</p>
+  <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively</p>
 </div>
 
   
@@ -1398,21 +1402,24 @@ has been processed.</p>
 <tr data-ice="property" data-depth="1">
       <td data-ice="name" class="code" data-depth="1">config.accessKeyId</td>
       <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span></td>
-      <td data-ice="appendix"></td>
+      <td data-ice="appendix"><ul><li>optional</li>
+<li>default: process.env.MWS_ACCESS_KEY</li></ul></td>
       <td data-ice="description"><p>Your MWS Access Key</p>
 </td>
     </tr>
 <tr data-ice="property" data-depth="1">
       <td data-ice="name" class="code" data-depth="1">config.secretAccessKey</td>
       <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span></td>
-      <td data-ice="appendix"></td>
+      <td data-ice="appendix"><ul><li>optional</li>
+<li>default: process.env.MWS_SECRET_ACCESS_KEY</li></ul></td>
       <td data-ice="description"><p>Your MWS Secret Access Key</p>
 </td>
     </tr>
 <tr data-ice="property" data-depth="1">
       <td data-ice="name" class="code" data-depth="1">config.merchantId</td>
       <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span></td>
-      <td data-ice="appendix"></td>
+      <td data-ice="appendix"><ul><li>optional</li>
+<li>default: process.env.MWS_MERCHANT_ID</li></ul></td>
       <td data-ice="description"><p>Your MWS Merchant ID</p>
 </td>
     </tr>

--- a/docs/identifiers.html
+++ b/docs/identifiers.html
@@ -103,7 +103,7 @@
           <span data-ice="kind-icon" class="kind-function">F</span>
           <span data-ice="async">async</span>
           
-          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, options: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span><span class="code" data-ice="signature">(name: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, callOptions: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>, opt: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a></span>): <span>any</span></span>
         </p>
       </div>
       <div>

--- a/docs/identifiers.html
+++ b/docs/identifiers.html
@@ -138,7 +138,9 @@
       <div>
         
         
-        <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port</p>
+        <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively</p>
 </div>
       </div>
     </td>

--- a/docs/source.html
+++ b/docs/source.html
@@ -94,13 +94,13 @@
   <tbody>
     
   <tr data-ice="file">
-      <td data-ice="filePath"><span><a href="file/lib/callEndpoint.js.html#errorLines=2,3,59,61,62,65">lib/callEndpoint.js</a></span></td>
+      <td data-ice="filePath"><span><a href="file/lib/callEndpoint.js.html#errorLines=2,3,62,64,65,68">lib/callEndpoint.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span>
 <span><a href="function/index.html#static-function-init">init</a></span></td>
       <td class="coverage"><span data-ice="coverage">45 %</span><span data-ice="coverageCount" class="coverage-count">5/11</span></td>
-      <td style="display: none;" data-ice="size">8033 byte</td>
-      <td style="display: none;" data-ice="lines">196</td>
-      <td style="display: none;" data-ice="updated">2018-01-05 16:48:51 (UTC)</td>
+      <td style="display: none;" data-ice="size">8422 byte</td>
+      <td style="display: none;" data-ice="lines">199</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 17:57:28 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/constants.js.html">lib/constants.js</a></span></td>

--- a/docs/source.html
+++ b/docs/source.html
@@ -94,13 +94,13 @@
   <tbody>
     
   <tr data-ice="file">
-      <td data-ice="filePath"><span><a href="file/lib/callEndpoint.js.html#errorLines=2,3,58,60,61,64">lib/callEndpoint.js</a></span></td>
+      <td data-ice="filePath"><span><a href="file/lib/callEndpoint.js.html#errorLines=2,3,59,61,62,65">lib/callEndpoint.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span>
 <span><a href="function/index.html#static-function-init">init</a></span></td>
       <td class="coverage"><span data-ice="coverage">45 %</span><span data-ice="coverageCount" class="coverage-count">5/11</span></td>
-      <td style="display: none;" data-ice="size">7162 byte</td>
-      <td style="display: none;" data-ice="lines">181</td>
-      <td style="display: none;" data-ice="updated">2018-01-05 08:17:13 (UTC)</td>
+      <td style="display: none;" data-ice="size">8033 byte</td>
+      <td style="display: none;" data-ice="lines">196</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 16:48:51 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/constants.js.html">lib/constants.js</a></span></td>
@@ -277,9 +277,9 @@
       <td data-ice="filePath"><span><a href="file/lib/list-financial-events.js.html#errorLines=1">lib/list-financial-events.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-listFinancialEvents">listFinancialEvents</a></span></td>
       <td class="coverage"><span data-ice="coverage">50 %</span><span data-ice="coverageCount" class="coverage-count">1/2</span></td>
-      <td style="display: none;" data-ice="size">821 byte</td>
-      <td style="display: none;" data-ice="lines">19</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
+      <td style="display: none;" data-ice="size">921 byte</td>
+      <td style="display: none;" data-ice="lines">23</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 16:30:14 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-inventory-supply.js.html#errorLines=1">lib/list-inventory-supply.js</a></span></td>

--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -1,6 +1,7 @@
 const MWS = require('mws-simple');
 const { MWS_ENDPOINTS } = require('./constants');
 const sleep = require('./sleep');
+const fs = require('fs');
 
 /*
  * TODO: split the "init" function out of the "callEndpoint" file, difficulty: callEndpoint
@@ -90,16 +91,17 @@ const endpoints = {
  * @async
  * @private
  * @param {any} requestData
+ * @param {object} [opt] - options
+ * @param {boolean} [opt.noFlatten] - do not run flattenResult on the output
  */
-const requestPromise = requestData =>
+const requestPromise = (requestData, opt = {}) =>
     new Promise((resolve, reject) => {
         // eslint-disable-next-line global-require
         mws.request(requestData, (err, result) => {
             if (err) {
                 reject(err);
             } else {
-                const flatResult = flattenResult(result);
-                resolve(flatResult);
+                resolve(opt.noFlatten ? result : flattenResult(result));
             }
         });
     });
@@ -111,17 +113,22 @@ const requestPromise = requestData =>
  * @async
  * @public
  * @param {string} name - name of MWS API function to call
- * @param {object} options - named hash object of the parameters to pass to the API
+ * @param {object} [callOptions] - named hash object of the parameters to pass to the API
+ * @param {object} [opt] - options for callEndpoint
+ * @param {boolean} [opt.noFlatten] - do not flatten results
+ * @param {boolean} [opt.returnRaw] - return only the raw data (may or may not be flattened)
+ * @param {string} [opt.saveRaw] - filename to save raw data to (may or may not be flattened)
+ * @param {string} [opt.saveParsed] - filename to save final parsed data to (not compatible with returnRaw, since parsing won't happen)
  * @returns {any} - Results of the call to MWS
  */
-const callEndpoint = async (name, options) => {
+const callEndpoint = async (name, callOptions = {}, opt = {}) => {
     const endpoint = endpoints[name];
     if (!endpoint) {
         throw new Error('No endpoint name supplied to callEndpoint');
     }
 
     const newOptions = endpoint.params ?
-        validateAndTransformParameters(endpoint.params, options) : options;
+        validateAndTransformParameters(endpoint.params, callOptions) : callOptions;
 
     const queryOptions = {
         ...newOptions,
@@ -135,12 +142,21 @@ const callEndpoint = async (name, options) => {
     };
 
     try {
-        const result = await requestPromise(params);
+        const result = await requestPromise(params, { noFlatten: opt.noFlatten });
+        if (opt.saveRaw) {
+            fs.writeFileSync(opt.saveRaw, JSON.stringify(result));
+        }
+        if (opt.returnRaw) {
+            return result;
+        }
         // TODO: add an option that will store the raw data, and a separate option to store the parsed
         // data, to file
         // const fs = require('fs');
         // fs.appendFile(`${name}-out.json`, JSON.stringify(result));
         const digResult = digResponseResult(name, result);
+        if (opt.saveParsed) {
+            fs.writeFileSync(opt.saveParsed, JSON.stringify(digResult));
+        }
         return digResult;
     } catch (err) {
         if (err.code === 503) {
@@ -168,7 +184,7 @@ const callEndpoint = async (name, options) => {
             }
             console.warn(`***** trying again in ${ms}ms`);
             await sleep(ms + 100);
-            return callEndpoint(name, options);
+            return callEndpoint(name, callOptions, opt);
         }
         throw err;
     }

--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -16,12 +16,14 @@ let mws = null;
 
 /**
  * Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
+ * If accessKeyId, secretAccessKey, and/or merchantId are not provided, they will be read from
+ * the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT_ID respectively
  *
  * @public
  * @param {object} config Contains your MWS Access Keys/Tokens and options to configure the API
- * @param {string} config.accessKeyId Your MWS Access Key
- * @param {string} config.secretAccessKey Your MWS Secret Access Key
- * @param {string} config.merchantId Your MWS Merchant ID
+ * @param {string} [config.accessKeyId=process.env.MWS_ACCESS_KEY] Your MWS Access Key
+ * @param {string} [config.secretAccessKey=process.env.MWS_SECRET_ACCESS_KEY] Your MWS Secret Access Key
+ * @param {string} [config.merchantId=process.env.MWS_MERCHANT_ID] Your MWS Merchant ID
  * @param {string} [config.authToken] If making a call for a third party account, the Auth Token provided
  *                           for the third party account
  * @param {string} [config.region='NA'] One of the Amazon regions as specified in https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html
@@ -29,12 +31,13 @@ let mws = null;
  * @param {number} [config.port=443] Set MWS host port
  * @returns {mws-simple} - The mws-simple instance used to communicate with the API
  */
+
 const init = ({
     region = 'NA',
     // marketplace = 'US', // TODO: maybe someday we will want to keep track of a 'default' marketplace.
-    accessKeyId,
-    secretAccessKey,
-    merchantId,
+    accessKeyId = process.env.MWS_ACCESS_KEY,
+    secretAccessKey = process.env.MWS_SECRET_ACCESS_KEY,
+    merchantId = process.env.MWS_MERCHANT_ID,
     authToken,
     host,
     port,

--- a/lib/endpoints/sellers.js
+++ b/lib/endpoints/sellers.js
@@ -13,7 +13,7 @@ const newEndpointList = {
     ListMarketplaceParticipations: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
         },
@@ -35,7 +35,7 @@ const newEndpointList = {
     ListMarketplaceParticipationsByNextToken: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             NextToken: {
@@ -61,7 +61,7 @@ const newEndpointList = {
     GetServiceStatus: {
         throttle: {
             maxInFlight: 2,
-            restoreRate: 12,
+            restoreRate: 0.20,
         },
         params: {
         },

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -388,6 +388,33 @@ describe('mws-advanced sanity', () => {
             mws.init(keys);
             return expect(mws.callEndpoint('ListMarketplaceParticipations', {})).to.be.fulfilled;
         });
+        it('callEndpoint saveRaw/saveParsed options', async () => {
+            try {
+                fs.unlinkSync('./testRaw.json');
+                fs.unlinkSync('./testParsed.json');
+            } catch (err) {
+                //
+            }
+            mws.init(keys);
+            await mws.callEndpoint('ListMarketplaceParticipations', {}, { noFlatten: true, saveRaw: './testRaw.json', saveParsed: './testParsed.json' });
+            expect(fs.existsSync('./testRaw.json')).to.equal(true);
+            expect(fs.existsSync('./testParsed.json')).to.equal(true);
+        });
+        it('callEndpoint returnRaw option', async () => {
+            mws.init(keys);
+            const x = await mws.callEndpoint('ListMarketplaceParticipations', {}, { returnRaw: true });
+            expect(x).to.be.an('Object');
+            expect(x).to.include.all.keys('ListMarketplaceParticipationsResponse');
+            expect(x.ListMarketplaceParticipationsResponse).to.include.all.keys('$', 'ListMarketplaceParticipationsResult', 'ResponseMetadata');
+            return true;
+        });
+        it('callEndpoint noFlatten option', async () => {
+            mws.init(keys);
+            const x = await mws.callEndpoint('ListMarketplaceParticipations', {}, { noFlatten: true });
+            expect(x).to.be.an('Array');
+            expect(x[0]).to.include.all.keys('ListParticipations', 'ListMarketplaces');
+            return true;
+        });
         // TODO: be more specific about which Error is being rejected back here, so when there's a code error in callEndpoint, it doesn't phantom pass
         it('callEndpoint throws on unknown endpoint', () => {
             return expect(mws.callEndpoint('/test/endpoint', {})).to.be.rejectedWith(Error);


### PR DESCRIPTION
- flattenResult is often a good thing, but on some things it turns
  the results into a mess. Therefore, provide an option to not call
  flattenResult
- Sometimes we may be interested in the total result prior to calling
  digResponseResult. returnRaw: true will provide that
- saveRaw will save the data to the specified file before calling
  digResponseResult
- saveParsed will save the data to the specified file after calling
  digResponseResult (returnRaw never calls dig so these are incompatible)
- The save options are to assist with implementing and debugging
  wrappers