### PR TITLE
add tests for (most of) remainder of reports category

### DIFF
--- a/API.md
+++ b/API.md
@@ -269,6 +269,34 @@ Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 **Parameters**
 
 -   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
 -   `subCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The subcondition of the item (New, Mint, Very Good, Good, Acceptable, Poor, Club, OEM, Warranty, Refurbished Warranty, Refurbished, Open Box, or Other)
 -   `sellerFeedbackRating` **SellerFeedbackRating** Information about the seller's feedback
 -   `shippingTime` **DetailedShippingTime** Maximum time within which the item will likely be shipped
@@ -279,34 +307,6 @@ Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 -   `isFulfilledByAmazon` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if FBA, False if not
 -   `isBuyBoxWinner` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if offer has buy box, False if not
 -   `isFeaturedMerchant` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if seller is eligible for Buy Box, False if not
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ## reformatLowestPrice
 
@@ -409,6 +409,21 @@ Returns **ReportRequestInfo**
 
 ## getReportRequestList
 
+**Parameters**
+
+-   `options`   (optional, default `{}`)
+-   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
+-   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
+-   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
+-   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
+-   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
+-   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
+-   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
+-   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
+-   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
+
+## getReportRequestList
+
 Returns a list of report requests that you can use to get the ReportRequestId for a report
 After calling requestReport, you should call this function occasionally to see if/when the report
 has been processed.
@@ -424,21 +439,6 @@ has been processed.
 -   `RequestedToDate` **[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)** Newest date to search for (optional, default `Now`)
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;GetReportRequestListResult>** 
-
-## getReportRequestList
-
-**Parameters**
-
--   `options`   (optional, default `{}`)
--   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
--   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
--   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
--   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
--   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
--   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
--   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
--   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
 
 ## getReport
 

--- a/docs/file/lib/callEndpoint.js.html
+++ b/docs/file/lib/callEndpoint.js.html
@@ -244,7 +244,7 @@ const callEndpoint = async (name, callOptions = {}, opt = {}) =&gt; {
         return digResult;
     } catch (err) {
         if (err.code === 503) {
-            console.warn(&apos;***** Error 503 .. throttling?&apos;);
+            console.warn(&apos;***** Error 503 .. throttling?&apos;, name);
             let ms = 2000;
             if (!endpoint.throttle) {
                 console.warn(`***** throttle information missing for API ${name}`);

--- a/docs/file/lib/endpoints/reports.js.html
+++ b/docs/file/lib/endpoints/reports.js.html
@@ -111,7 +111,7 @@ const newEndpointList = {
     RequestReport: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             ReportType: {
@@ -145,7 +145,7 @@ const newEndpointList = {
     GetReportRequestList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78, // approximate, you get one back every 45 seconds, so roughly 78 per hour
+            restoreRate: 0.75, // 1 request every 45 seconds = 3/4 of a request per minute
         },
         params: {
             ReportRequestIdList: {
@@ -197,7 +197,7 @@ const newEndpointList = {
     GetReportRequestListByNextToken: {
         throttle: {
             maxInFlight: 30,
-            restoreRate: 1800,
+            restoreRate: 30,
         },
         params: {
             NextToken: {
@@ -223,7 +223,7 @@ const newEndpointList = {
     GetReportRequestCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -255,7 +255,7 @@ const newEndpointList = {
     CancelReportRequests: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportRequestIdList: {
@@ -297,7 +297,7 @@ const newEndpointList = {
     GetReportList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             MaxCount: {
@@ -351,7 +351,7 @@ const newEndpointList = {
     GetReportListByNextToken: {
         throttle: {
             maxInFlight: 30,
-            restoreRate: 1800,
+            restoreRate: 30,
         },
         params: {
             NextToken: {
@@ -377,7 +377,7 @@ const newEndpointList = {
     GetReportCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -413,7 +413,7 @@ const newEndpointList = {
     GetReport: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             ReportId: {
@@ -431,7 +431,7 @@ const newEndpointList = {
     ManageReportSchedule: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportType: {
@@ -463,7 +463,7 @@ const newEndpointList = {
     GetReportScheduleList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -516,7 +516,7 @@ const newEndpointList = {
     GetReportScheduleCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -539,7 +539,7 @@ const newEndpointList = {
     UpdateReportAcknowledgements: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportIdList: {

--- a/docs/file/lib/endpoints/sellers.js.html
+++ b/docs/file/lib/endpoints/sellers.js.html
@@ -94,7 +94,7 @@ const newEndpointList = {
     ListMarketplaceParticipations: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
         },
@@ -116,7 +116,7 @@ const newEndpointList = {
     ListMarketplaceParticipationsByNextToken: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             NextToken: {
@@ -142,7 +142,7 @@ const newEndpointList = {
     GetServiceStatus: {
         throttle: {
             maxInFlight: 2,
-            restoreRate: 12,
+            restoreRate: 0.20,
         },
         params: {
         },

--- a/docs/source.html
+++ b/docs/source.html
@@ -98,9 +98,9 @@
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span>
 <span><a href="function/index.html#static-function-init">init</a></span></td>
       <td class="coverage"><span data-ice="coverage">45 %</span><span data-ice="coverageCount" class="coverage-count">5/11</span></td>
-      <td style="display: none;" data-ice="size">8422 byte</td>
+      <td style="display: none;" data-ice="size">8428 byte</td>
       <td style="display: none;" data-ice="lines">199</td>
-      <td style="display: none;" data-ice="updated">2018-01-05 17:57:28 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 18:54:46 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/constants.js.html">lib/constants.js</a></span></td>
@@ -221,9 +221,9 @@
       <td data-ice="filePath"><span><a href="file/lib/endpoints/reports.js.html#errorLines=10,12,29,3,5,7,8">lib/endpoints/reports.js</a></span></td>
       <td data-ice="identifier" class="identifiers">-</td>
       <td class="coverage"><span data-ice="coverage">12 %</span><span data-ice="coverageCount" class="coverage-count">1/8</span></td>
-      <td style="display: none;" data-ice="size">14397 byte</td>
+      <td style="display: none;" data-ice="size">14392 byte</td>
       <td style="display: none;" data-ice="lines">498</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 18:58:20 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/sellers.js.html#errorLines=1,12,3,5,7">lib/endpoints/sellers.js</a></span></td>
@@ -231,7 +231,7 @@
       <td class="coverage"><span data-ice="coverage">16 %</span><span data-ice="coverageCount" class="coverage-count">1/6</span></td>
       <td style="display: none;" data-ice="size">2829 byte</td>
       <td style="display: none;" data-ice="lines">109</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 18:03:14 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/flatten-result.js.html">lib/flatten-result.js</a></span></td>

--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -163,7 +163,7 @@ const callEndpoint = async (name, callOptions = {}, opt = {}) => {
         return digResult;
     } catch (err) {
         if (err.code === 503) {
-            console.warn('***** Error 503 .. throttling?');
+            console.warn('***** Error 503 .. throttling?', name);
             let ms = 2000;
             if (!endpoint.throttle) {
                 console.warn(`***** throttle information missing for API ${name}`);

--- a/lib/endpoints/reports.js
+++ b/lib/endpoints/reports.js
@@ -30,7 +30,7 @@ const newEndpointList = {
     RequestReport: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             ReportType: {
@@ -64,7 +64,7 @@ const newEndpointList = {
     GetReportRequestList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78, // approximate, you get one back every 45 seconds, so roughly 78 per hour
+            restoreRate: 0.75, // 1 request every 45 seconds = 3/4 of a request per minute
         },
         params: {
             ReportRequestIdList: {
@@ -116,7 +116,7 @@ const newEndpointList = {
     GetReportRequestListByNextToken: {
         throttle: {
             maxInFlight: 30,
-            restoreRate: 1800,
+            restoreRate: 30,
         },
         params: {
             NextToken: {
@@ -142,7 +142,7 @@ const newEndpointList = {
     GetReportRequestCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -174,7 +174,7 @@ const newEndpointList = {
     CancelReportRequests: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportRequestIdList: {
@@ -216,7 +216,7 @@ const newEndpointList = {
     GetReportList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             MaxCount: {
@@ -270,7 +270,7 @@ const newEndpointList = {
     GetReportListByNextToken: {
         throttle: {
             maxInFlight: 30,
-            restoreRate: 1800,
+            restoreRate: 30,
         },
         params: {
             NextToken: {
@@ -296,7 +296,7 @@ const newEndpointList = {
     GetReportCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -332,7 +332,7 @@ const newEndpointList = {
     GetReport: {
         throttle: {
             maxInFlight: 15,
-            restoreRate: 60,
+            restoreRate: 1,
         },
         params: {
             ReportId: {
@@ -350,7 +350,7 @@ const newEndpointList = {
     ManageReportSchedule: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportType: {
@@ -382,7 +382,7 @@ const newEndpointList = {
     GetReportScheduleList: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -435,7 +435,7 @@ const newEndpointList = {
     GetReportScheduleCount: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportTypeList: {
@@ -458,7 +458,7 @@ const newEndpointList = {
     UpdateReportAcknowledgements: {
         throttle: {
             maxInFlight: 10,
-            restoreRate: 78,
+            restoreRate: 0.75,
         },
         params: {
             ReportIdList: {


### PR DESCRIPTION
- could not find any request that would give me a nextToken, will have
  to try harder on that one another time, probably when I do a pass to
  try to ensure that nextToken functions are all implemented/working
- also add name of throttled API to throttle console output
- fix reports category throttles to all restoreRate = # of items per min
- move reports tests to the end of testing, as they may take a significant
  amount of time to complete