### PR TITLE
optimization in init() when dealing with region/host combos

### DIFF
--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -39,21 +39,15 @@ const init = ({
     secretAccessKey = process.env.MWS_SECRET_ACCESS_KEY,
     merchantId = process.env.MWS_MERCHANT_ID,
     authToken,
-    host,
+    host = MWS_ENDPOINTS[region] || 'mws.amazonservices.com',
     port,
 } = {}) => {
-    let newHost = host;
-    if (!MWS_ENDPOINTS[region]) {
-        console.warn(`**** ${region} not known! Things may not work right or at all. Using default host mws-amazonservices.com`);
-    } else if (!newHost) {
-        newHost = MWS_ENDPOINTS[region];
-    }
     mws = new MWS({
         accessKeyId,
         secretAccessKey,
         merchantId,
         authToken,
-        host: newHost,
+        host,
         port,
     });
     return mws;

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -311,6 +311,7 @@ const mws = require('..');
 
 let SkipAPITests = false;
 let keys;
+
 try {
     keys = require('./keys.json');
 } catch (err) {
@@ -704,7 +705,12 @@ describe('API', function runAPITests() {
     describe('Reports Category', () => {
         let reportList = [];
         let ReportRequestId = null;
-        it('requestReport', async () => {
+        it('requestReport', async function () {
+            if (!process.env.REPORTS_TESTS) {
+                console.warn('* skipping reports tests (set env REPORTS_TESTS=true to perform)');
+                this.skip();
+                return false;
+            }
             const report = await mws.requestReport({
                 ReportType: '_GET_V1_SELLER_PERFORMANCE_REPORT_',
             });
@@ -723,6 +729,11 @@ describe('API', function runAPITests() {
         });
         it('getReportRequestList (timeout disabled, retries until status shows a done or cancelled state)', async function testGetReportRequestList() {
             if (!ReportRequestId) {
+                this.skip();
+                return false;
+            }
+            if (!process.env.REPORTS_TESTS) {
+                console.warn('* skipping reports tests');
                 this.skip();
                 return false;
             }
@@ -745,6 +756,11 @@ describe('API', function runAPITests() {
             return true;
         });
         it('getReportListAll', async function testGetReportListAll() {
+            if (!process.env.REPORTS_TESTS) {
+                console.warn('* skipping reports tests');
+                this.skip();
+                return false;
+            }
             reportList = await mws.getReportListAll({
                 ReportTypeList: ['_GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE_'],
             });
@@ -757,6 +773,12 @@ describe('API', function runAPITests() {
                 this.skip();
                 return false;
             }
+            if (!process.env.REPORTS_TESTS) {
+                console.warn('* skipping reports tests');
+                this.skip();
+                return false;
+            }
+
             const report = await mws.getReport({
                 ReportId: reportList[0].ReportId,
             });
@@ -774,6 +796,11 @@ describe('API', function runAPITests() {
             return settlement;
         });
         it('requestAndDownloadReport (timeout 60000ms)', async function testRequestDownloadReport() {
+            if (!process.env.REPORTS_TESTS) {
+                console.warn('* skipping reports tests');
+                this.skip();
+                return false;
+            }
             this.timeout(60000);
             await mws.requestAndDownloadReport('_GET_FLAT_FILE_OPEN_LISTINGS_DATA_', './test-listings.json');
             expect(fs.existsSync('./test-listings.json')).to.equal(true);


### PR DESCRIPTION
- unit testing discovered there was some code that was never being hit,
  so i realized that section was a bit of a mess, and fixed it to read
  better. :)
- also add use of "REPORTS_TESTS" environment variable. If not set, reports tests will be skipped. This is because these tests can take a LONG time to run, so we only want to run them on the builder if possible, as normal developer testing will probably not involve them.