### PR TITLE
use custom error classes for throwing errors

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,8 +11,13 @@
 -   [callEndpoint](#callendpoint)
 -   [MWS_MARKETPLACES](#mws_marketplaces)
 -   [MWS_ENDPOINTS](#mws_endpoints)
+-   [InvalidUsage](#invalidusage)
+-   [ServiceError](#serviceerror)
+-   [RequestCancelled](#requestcancelled)
+-   [ValidationError](#validationerror)
 -   [recursionCount](#recursioncount)
 -   [rootWasArray](#rootwasarray)
+-   [validateInteger](#validateinteger)
 -   [feeds](#feeds)
 -   [REQUEST_REPORT_TYPES](#request_report_types)
 -   [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
@@ -121,6 +126,30 @@ A list of Marketplace IDs hashed by their country code.
 
 A list of hosts you can use with the mws-advanced "host" option, hashed by MWS Region Name.
 
+## InvalidUsage
+
+**Extends Error**
+
+Thrown when completely Invalid Parameters are given and we have no way of making sense of them
+
+## ServiceError
+
+**Extends extError**
+
+Thrown when an Error response comes from the Service (not a mws-simple.ServerError though)
+
+## RequestCancelled
+
+**Extends extError**
+
+Thrown when a request is cancelled by MWS -- we have no way of knowing automatically if we should retry or not
+
+## ValidationError
+
+**Extends extError**
+
+Thrown when parameters fail validation locally, before being sent to MWS
+
 ## recursionCount
 
 flattenResult does some recursion. We need to act differently on the initial iteration.
@@ -128,6 +157,16 @@ flattenResult does some recursion. We need to act differently on the initial ite
 ## rootWasArray
 
 determine if flattenResult was called with an Array as the root
+
+## validateInteger
+
+**Parameters**
+
+-   `type` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** type of integer to validate (xs:int, xs:positiveInteger, etc)
+-   `test` **any** value to test
+-   `minmax` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** minimum and maximum values to test for (optional, default `{}`)
+    -   `minmax.minValue` **integer** minimum value to test for
+    -   `minmax.maxValue` **integer** maximum value to test for
 
 ## feeds
 
@@ -179,15 +218,6 @@ Returns **MarketDetail**
 
 ## listOrderItems
 
-**Parameters**
-
--   `AmazonOrderId`  
--   `orderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Amazon Order ID
--   `nextToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
--   `orderItems` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Array of all the items in the order
-
-## listOrderItems
-
 Returns order items based on the AmazonOrderId that you specify.
 
 If you've pulled a list of orders using @see [ListOrders](ListOrders), or have order identifiers
@@ -207,6 +237,15 @@ ShippingDiscount
 -   `AmazonOrderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 3-7-7 Amazon Order ID formatted string
 
 Returns **OrderItemList** 
+
+## listOrderItems
+
+**Parameters**
+
+-   `AmazonOrderId`  
+-   `orderId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Amazon Order ID
+-   `nextToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
+-   `orderItems` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Array of all the items in the order
 
 ## listOrders
 
@@ -311,34 +350,6 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 **Parameters**
 
 -   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
 -   `subCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The subcondition of the item (New, Mint, Very Good, Good, Acceptable, Poor, Club, OEM, Warranty, Refurbished Warranty, Refurbished, Open Box, or Other)
 -   `sellerFeedbackRating` **SellerFeedbackRating** Information about the seller's feedback
 -   `shippingTime` **DetailedShippingTime** Maximum time within which the item will likely be shipped
@@ -349,6 +360,34 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 -   `isFulfilledByAmazon` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if FBA, False if not
 -   `isBuyBoxWinner` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if offer has buy box, False if not
 -   `isFeaturedMerchant` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** True if seller is eligible for Buy Box, False if not
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ## reformatLowestPrice
 
@@ -384,17 +423,6 @@ Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 
 ## getLowestPricedOffersForASIN
 
-**Parameters**
-
--   `options`  
--   `asin` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** asin returned by request
--   `marketplace` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** marketplace asin is in
--   `itemCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** condition of item requested
--   `summary` **OfferSummary** \-
--   `offers` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Offers>** list of offers
-
-## getLowestPricedOffersForASIN
-
 getLowestPricedOffersForASIN
 
 Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
@@ -408,6 +436,17 @@ Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
 
 Returns **LowestPricedOffers** 
 
+## getLowestPricedOffersForASIN
+
+**Parameters**
+
+-   `options`  
+-   `asin` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** asin returned by request
+-   `marketplace` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** marketplace asin is in
+-   `itemCondition` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** condition of item requested
+-   `summary` **OfferSummary** \-
+-   `offers` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Offers>** list of offers
+
 ## writeFile
 
 Promisified version of fs.writeFile
@@ -419,6 +458,19 @@ This is better than using writeFileSync. Trust me. :-)
 
 -   `fileName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** path/filename to write to
 -   `contents` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Buffer](https://nodejs.org/api/buffer.html))** what to write to file
+
+## requestReport
+
+**Parameters**
+
+-   `options`  
+-   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
+-   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
+-   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date Ending period
+-   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
+-   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to fetch the report when ready
+-   `SubmittedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date request was submitted
+-   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date report begins at
 
 ## requestReport
 
@@ -436,18 +488,20 @@ Many optional parameters may be required by MWS! Read [ReportType](https://docs.
 
 Returns **ReportRequestInfo** 
 
-## requestReport
+## getReportRequestList
 
 **Parameters**
 
--   `options`  
+-   `options`   (optional, default `{}`)
 -   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
 -   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
--   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date Ending period
+-   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
 -   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to fetch the report when ready
--   `SubmittedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date request was submitted
--   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Date report begins at
+-   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
+-   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
+-   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
+-   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
+-   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
 
 ## getReportRequestList
 
@@ -466,21 +520,6 @@ has been processed.
 -   `RequestedToDate` **[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)** Newest date to search for (optional, default `Now`)
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;GetReportRequestListResult>** 
-
-## getReportRequestList
-
-**Parameters**
-
--   `options`   (optional, default `{}`)
--   `ReportType` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of Report Requested @see [REQUEST_REPORT_TYPES](#request_report_types)
--   `ReportProcessingStatus` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES](#report_processing_status_types)
--   `EndDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report End Period
--   `Scheduled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier for the Report Request
--   `StartedProcessingDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS started processing request
--   `StartDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for Report Start Period
--   `CompletedDate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** ISO Date for time MWS completed processing request
--   `GeneratedReportId` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Identifier to use with getReport to retrieve the report
 
 ## getReport
 

--- a/docs/badge.svg
+++ b/docs/badge.svg
@@ -11,7 +11,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="32" y="15" fill="#010101" fill-opacity=".3">document</text>
     <text x="32" y="14">document</text>
-    <text x="84" y="15" fill="#010101" fill-opacity=".3">57%</text>
-    <text x="84" y="14">57%</text>
+    <text x="84" y="15" fill="#010101" fill-opacity=".3">59%</text>
+    <text x="84" y="14">59%</text>
   </g>
 </svg>

--- a/docs/class/lib/errors.js~InvalidUsage.html
+++ b/docs/class/lib/errors.js~InvalidUsage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/validation.js | mws-advanced</title>
+  <title data-ice="title">InvalidUsage | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -72,173 +72,58 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/validation.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
+<div class="content" data-ice="content"><div class="header-notice">
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {InvalidUsage} from &apos;<span><a href="file/lib/errors.js.html#lineNumber9">mws-advanced/lib/errors.js</a></span>&apos;</code></pre></div>
+  <span data-ice="access">public</span>
+  <span data-ice="kind">class</span>
+  
+  
+  
+  <span data-ice="source">| <span><a href="file/lib/errors.js.html#lineNumber9">source</a></span></span>
+</div>
 
-// TODO: testing indicates some weirdness in this call. It throws for things that are outside of
-// ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
-// does not throw for basic type incompatibility, relying on it&apos;s caller to throw. Should this throw
-// on all errors, or should it not throw on any errors? It&apos;s a lot easier to determine the *reason*
-// for the throw here, so I lean towards fixing this to throw an error for all invalid things. For
-// right now, I&apos;m going to leave it exactly as is, because there&apos;s always a throw at the end user,
-// but this makes unit testing weird.
+<div class="self-detail detail">
+  <h1 data-ice="name">InvalidUsage</h1>
 
-// we expect xs:dateTime to come in as a ISO string. This is a little confusing because the
-// consumer, validateAndTransform allows Date objects as input.
-/* eslint-disable no-param-reassign */
-/**
- *
- *
- * @param {string} type - type of integer to validate (xs:int, xs:positiveInteger, etc)
- * @param {any} test - value to test
- * @param {object} minmax - minimum and maximum values to test for
- * @param {integer} minmax.minValue - minimum value to test for
- * @param {integer} minmax.maxValue - maximum value to test for
- */
-const validateInteger = (type, test, { minValue, maxValue } = { }) =&gt; {
-    if (minValue === undefined) {
-        if (type === &apos;xs:positiveInteger&apos;) minValue = 1;
-        else if (type === &apos;xs:nonNegativeInteger&apos;) minValue = 0;
-        else minValue = -2147483658;
-    }
-    if (maxValue === undefined) {
-        maxValue = 2147483647;
-    }
-    const newTest = parseInt(test, 10);
-    // eslint-disable-next-line eqeqeq
-    const valid = test == newTest &amp;&amp; (minValue == null || newTest &gt;= minValue) &amp;&amp; (maxValue == null || newTest &lt;= maxValue);
-    if (!valid) {
-        throw new errors.ValidationError(`Expected type ${type} ${minValue} &lt;= ${test} &lt;= ${maxValue}`);
-    }
-    return valid;
-};
+  
 
-/**
- * Tests if an item belongs to a given type, and validates values and other stuff.
- * This function is currently overloaded to do too much. Sorry. The end consumer of *this* function,
- * validateAndTransform, is handling crazier stuff.
- * @private
- * @param {string} type data type referenced from MWS documentation (ie, &apos;xs:positiveInteger&apos;)
- * @param {any} test data to test against the given type
- * @param {any} definition validation definition (see lib/endpoints)
- * @returns Boolean true if correct type AND valid, false if not. Throws on many errors.
- */
-const isType = (type, test, definition) =&gt; {
-    let valid = false;
-    switch (type) {
-        case &apos;xs:int&apos;:
-        case &apos;xs:positiveInteger&apos;: // fallthrough from xs:int intentional
-        case &apos;xs:nonNegativeInteger&apos;: // fallthrough from xs:positiveInteger intentional
-            valid = validateInteger(type, test, definition);
-            break;
-        case &apos;xs:string&apos;:
-            if (typeof test === &apos;string&apos; || test instanceof String) {
-                valid = true;
-            }
-            break;
-        case &apos;xs:dateTime&apos;: // test for exact match to ISO8601
-            if (new Date(test).toISOString() === test) {
-                valid = true;
-            }
-            break;
-        default:
-            console.log(`** isType: dont know how to handle type ${type}, hope its good`);
-            valid = true;
-    }
-    if (valid &amp;&amp; definition &amp;&amp; definition.values &amp;&amp; !definition.values.includes(test)) {
-        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
-    }
-    return valid;
-};
-/**
- * The &quot;validate&quot; step of &quot;validateAndTransform&quot; will happen here. See discussion here:
- * https://github.com/ericblade/mws-advanced/pull/20
- *
- * @private
- * @param {any} test
- * @param {any} definition
- * @returns
- */
-function validate(test, definition) {
-    let validOrderId = false;
-    const re = /\d{3}-\d{7}-\d{3}/g;
-    if (re.test(test) &amp;&amp; definition.stringFormat === &apos;amazonOrderId&apos;) {
-        validOrderId = true;
-    }
-    return validOrderId;
-}
+  
+  
+  <div class="flat-list" data-ice="extendsChain"><h4>Extends:</h4><div><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a></span> &#x2192; InvalidUsage</div></div>
+  
+  
+  
+  
+  
+  
 
-/**
- * Used to both validate and transform &quot;normal&quot; javascript parameters (such as regular strings,
- * arrays, object hashes, and Date objects) into something that the underlying MWS system can
- * understand.
- *
- * @private
- * @param {any} valid
- * @param {any} options
- * @returns
- */
-const validateAndTransformParameters = (valid, options) =&gt; {
-    if (!options) {
-        return {};
-    }
-    if (!valid) {
-        console.warn(&apos;**** no validation parameters passed to validateAndTransform, no checking will be performed&apos;);
-        return options;
-    }
+  
+  
+  <div class="description" data-ice="description"><p>Thrown when completely Invalid Parameters are given and we have no way of making sense of them</p>
+</div>
+  
 
-    const newOptions = {};
-    // check for unknown parameters
-    Object.keys(options).forEach((k) =&gt; {
-        if (!valid[k]) {
-            throw new errors.ValidationError(`Unknown parameter ${k}`);
-        }
-    });
-    // check for required, list, and type (inside and outside of list)
-    // transform lists into the expected keys at the MWS side.
-    // ie key AmazonOrderId becomes AmazonOrderId.Id.{index}
-    Object.keys(valid).forEach((k) =&gt; {
-        const v = valid[k];
-        const o = options[k];
+  
 
-        // if required and not found, throw
-        if (v.required &amp;&amp; !o) {
-            throw new errors.ValidationError(`Required parameter ${k} missing`);
-        }
-        // transform Date objects into ISO strings
-        if (v.type === &apos;xs:dateTime&apos; &amp;&amp; o instanceof Date) {
-            newOptions[k] = o.toISOString();
-        } else if (v.list &amp;&amp; o) { // transform lists
-            if (!Array.isArray(o)) {
-                throw new errors.ValidationError(`Parameter ${k} expected an array`);
-            }
-            if (v.listMax &amp;&amp; o.length &gt; v.listMax) {
-                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
-            }
-            if (!o.every(val =&gt; isType(v.type, val, v))) {
-                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
-            }
-            o.forEach((item, index) =&gt; {
-                newOptions[`${v.list}.${index + 1}`] = item;
-            });
-        } else { // if not already handled, then run it through isType
-            if (v &amp;&amp; o &amp;&amp; !isType(v.type, o, v)) {
-                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
-            }
-            if (k &amp;&amp; o) {
-                newOptions[k] = o;
-            }
-        }
-    });
-    return newOptions;
-};
+  
 
-module.exports = {
-    isType,
-    validate,
-    validateAndTransformParameters,
-};
-</code></pre>
+  
+
+  
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 </div>
 

--- a/docs/class/lib/errors.js~RequestCancelled.html
+++ b/docs/class/lib/errors.js~RequestCancelled.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/validation.js | mws-advanced</title>
+  <title data-ice="title">RequestCancelled | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -72,173 +72,58 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/validation.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
+<div class="content" data-ice="content"><div class="header-notice">
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {RequestCancelled} from &apos;<span><a href="file/lib/errors.js.html#lineNumber25">mws-advanced/lib/errors.js</a></span>&apos;</code></pre></div>
+  <span data-ice="access">public</span>
+  <span data-ice="kind">class</span>
+  
+  
+  
+  <span data-ice="source">| <span><a href="file/lib/errors.js.html#lineNumber25">source</a></span></span>
+</div>
 
-// TODO: testing indicates some weirdness in this call. It throws for things that are outside of
-// ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
-// does not throw for basic type incompatibility, relying on it&apos;s caller to throw. Should this throw
-// on all errors, or should it not throw on any errors? It&apos;s a lot easier to determine the *reason*
-// for the throw here, so I lean towards fixing this to throw an error for all invalid things. For
-// right now, I&apos;m going to leave it exactly as is, because there&apos;s always a throw at the end user,
-// but this makes unit testing weird.
+<div class="self-detail detail">
+  <h1 data-ice="name">RequestCancelled</h1>
 
-// we expect xs:dateTime to come in as a ISO string. This is a little confusing because the
-// consumer, validateAndTransform allows Date objects as input.
-/* eslint-disable no-param-reassign */
-/**
- *
- *
- * @param {string} type - type of integer to validate (xs:int, xs:positiveInteger, etc)
- * @param {any} test - value to test
- * @param {object} minmax - minimum and maximum values to test for
- * @param {integer} minmax.minValue - minimum value to test for
- * @param {integer} minmax.maxValue - maximum value to test for
- */
-const validateInteger = (type, test, { minValue, maxValue } = { }) =&gt; {
-    if (minValue === undefined) {
-        if (type === &apos;xs:positiveInteger&apos;) minValue = 1;
-        else if (type === &apos;xs:nonNegativeInteger&apos;) minValue = 0;
-        else minValue = -2147483658;
-    }
-    if (maxValue === undefined) {
-        maxValue = 2147483647;
-    }
-    const newTest = parseInt(test, 10);
-    // eslint-disable-next-line eqeqeq
-    const valid = test == newTest &amp;&amp; (minValue == null || newTest &gt;= minValue) &amp;&amp; (maxValue == null || newTest &lt;= maxValue);
-    if (!valid) {
-        throw new errors.ValidationError(`Expected type ${type} ${minValue} &lt;= ${test} &lt;= ${maxValue}`);
-    }
-    return valid;
-};
+  
 
-/**
- * Tests if an item belongs to a given type, and validates values and other stuff.
- * This function is currently overloaded to do too much. Sorry. The end consumer of *this* function,
- * validateAndTransform, is handling crazier stuff.
- * @private
- * @param {string} type data type referenced from MWS documentation (ie, &apos;xs:positiveInteger&apos;)
- * @param {any} test data to test against the given type
- * @param {any} definition validation definition (see lib/endpoints)
- * @returns Boolean true if correct type AND valid, false if not. Throws on many errors.
- */
-const isType = (type, test, definition) =&gt; {
-    let valid = false;
-    switch (type) {
-        case &apos;xs:int&apos;:
-        case &apos;xs:positiveInteger&apos;: // fallthrough from xs:int intentional
-        case &apos;xs:nonNegativeInteger&apos;: // fallthrough from xs:positiveInteger intentional
-            valid = validateInteger(type, test, definition);
-            break;
-        case &apos;xs:string&apos;:
-            if (typeof test === &apos;string&apos; || test instanceof String) {
-                valid = true;
-            }
-            break;
-        case &apos;xs:dateTime&apos;: // test for exact match to ISO8601
-            if (new Date(test).toISOString() === test) {
-                valid = true;
-            }
-            break;
-        default:
-            console.log(`** isType: dont know how to handle type ${type}, hope its good`);
-            valid = true;
-    }
-    if (valid &amp;&amp; definition &amp;&amp; definition.values &amp;&amp; !definition.values.includes(test)) {
-        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
-    }
-    return valid;
-};
-/**
- * The &quot;validate&quot; step of &quot;validateAndTransform&quot; will happen here. See discussion here:
- * https://github.com/ericblade/mws-advanced/pull/20
- *
- * @private
- * @param {any} test
- * @param {any} definition
- * @returns
- */
-function validate(test, definition) {
-    let validOrderId = false;
-    const re = /\d{3}-\d{7}-\d{3}/g;
-    if (re.test(test) &amp;&amp; definition.stringFormat === &apos;amazonOrderId&apos;) {
-        validOrderId = true;
-    }
-    return validOrderId;
-}
+  
+  
+  <div class="flat-list" data-ice="extendsChain"><h4>Extends:</h4><div><span>extError</span> &#x2192; RequestCancelled</div></div>
+  
+  
+  
+  
+  
+  
 
-/**
- * Used to both validate and transform &quot;normal&quot; javascript parameters (such as regular strings,
- * arrays, object hashes, and Date objects) into something that the underlying MWS system can
- * understand.
- *
- * @private
- * @param {any} valid
- * @param {any} options
- * @returns
- */
-const validateAndTransformParameters = (valid, options) =&gt; {
-    if (!options) {
-        return {};
-    }
-    if (!valid) {
-        console.warn(&apos;**** no validation parameters passed to validateAndTransform, no checking will be performed&apos;);
-        return options;
-    }
+  
+  
+  <div class="description" data-ice="description"><p>Thrown when a request is cancelled by MWS -- we have no way of knowing automatically if we should retry or not</p>
+</div>
+  
 
-    const newOptions = {};
-    // check for unknown parameters
-    Object.keys(options).forEach((k) =&gt; {
-        if (!valid[k]) {
-            throw new errors.ValidationError(`Unknown parameter ${k}`);
-        }
-    });
-    // check for required, list, and type (inside and outside of list)
-    // transform lists into the expected keys at the MWS side.
-    // ie key AmazonOrderId becomes AmazonOrderId.Id.{index}
-    Object.keys(valid).forEach((k) =&gt; {
-        const v = valid[k];
-        const o = options[k];
+  
 
-        // if required and not found, throw
-        if (v.required &amp;&amp; !o) {
-            throw new errors.ValidationError(`Required parameter ${k} missing`);
-        }
-        // transform Date objects into ISO strings
-        if (v.type === &apos;xs:dateTime&apos; &amp;&amp; o instanceof Date) {
-            newOptions[k] = o.toISOString();
-        } else if (v.list &amp;&amp; o) { // transform lists
-            if (!Array.isArray(o)) {
-                throw new errors.ValidationError(`Parameter ${k} expected an array`);
-            }
-            if (v.listMax &amp;&amp; o.length &gt; v.listMax) {
-                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
-            }
-            if (!o.every(val =&gt; isType(v.type, val, v))) {
-                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
-            }
-            o.forEach((item, index) =&gt; {
-                newOptions[`${v.list}.${index + 1}`] = item;
-            });
-        } else { // if not already handled, then run it through isType
-            if (v &amp;&amp; o &amp;&amp; !isType(v.type, o, v)) {
-                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
-            }
-            if (k &amp;&amp; o) {
-                newOptions[k] = o;
-            }
-        }
-    });
-    return newOptions;
-};
+  
 
-module.exports = {
-    isType,
-    validate,
-    validateAndTransformParameters,
-};
-</code></pre>
+  
+
+  
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 </div>
 

--- a/docs/class/lib/errors.js~ServiceError.html
+++ b/docs/class/lib/errors.js~ServiceError.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/validation.js | mws-advanced</title>
+  <title data-ice="title">ServiceError | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -72,173 +72,58 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/validation.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
+<div class="content" data-ice="content"><div class="header-notice">
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {ServiceError} from &apos;<span><a href="file/lib/errors.js.html#lineNumber17">mws-advanced/lib/errors.js</a></span>&apos;</code></pre></div>
+  <span data-ice="access">public</span>
+  <span data-ice="kind">class</span>
+  
+  
+  
+  <span data-ice="source">| <span><a href="file/lib/errors.js.html#lineNumber17">source</a></span></span>
+</div>
 
-// TODO: testing indicates some weirdness in this call. It throws for things that are outside of
-// ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
-// does not throw for basic type incompatibility, relying on it&apos;s caller to throw. Should this throw
-// on all errors, or should it not throw on any errors? It&apos;s a lot easier to determine the *reason*
-// for the throw here, so I lean towards fixing this to throw an error for all invalid things. For
-// right now, I&apos;m going to leave it exactly as is, because there&apos;s always a throw at the end user,
-// but this makes unit testing weird.
+<div class="self-detail detail">
+  <h1 data-ice="name">ServiceError</h1>
 
-// we expect xs:dateTime to come in as a ISO string. This is a little confusing because the
-// consumer, validateAndTransform allows Date objects as input.
-/* eslint-disable no-param-reassign */
-/**
- *
- *
- * @param {string} type - type of integer to validate (xs:int, xs:positiveInteger, etc)
- * @param {any} test - value to test
- * @param {object} minmax - minimum and maximum values to test for
- * @param {integer} minmax.minValue - minimum value to test for
- * @param {integer} minmax.maxValue - maximum value to test for
- */
-const validateInteger = (type, test, { minValue, maxValue } = { }) =&gt; {
-    if (minValue === undefined) {
-        if (type === &apos;xs:positiveInteger&apos;) minValue = 1;
-        else if (type === &apos;xs:nonNegativeInteger&apos;) minValue = 0;
-        else minValue = -2147483658;
-    }
-    if (maxValue === undefined) {
-        maxValue = 2147483647;
-    }
-    const newTest = parseInt(test, 10);
-    // eslint-disable-next-line eqeqeq
-    const valid = test == newTest &amp;&amp; (minValue == null || newTest &gt;= minValue) &amp;&amp; (maxValue == null || newTest &lt;= maxValue);
-    if (!valid) {
-        throw new errors.ValidationError(`Expected type ${type} ${minValue} &lt;= ${test} &lt;= ${maxValue}`);
-    }
-    return valid;
-};
+  
 
-/**
- * Tests if an item belongs to a given type, and validates values and other stuff.
- * This function is currently overloaded to do too much. Sorry. The end consumer of *this* function,
- * validateAndTransform, is handling crazier stuff.
- * @private
- * @param {string} type data type referenced from MWS documentation (ie, &apos;xs:positiveInteger&apos;)
- * @param {any} test data to test against the given type
- * @param {any} definition validation definition (see lib/endpoints)
- * @returns Boolean true if correct type AND valid, false if not. Throws on many errors.
- */
-const isType = (type, test, definition) =&gt; {
-    let valid = false;
-    switch (type) {
-        case &apos;xs:int&apos;:
-        case &apos;xs:positiveInteger&apos;: // fallthrough from xs:int intentional
-        case &apos;xs:nonNegativeInteger&apos;: // fallthrough from xs:positiveInteger intentional
-            valid = validateInteger(type, test, definition);
-            break;
-        case &apos;xs:string&apos;:
-            if (typeof test === &apos;string&apos; || test instanceof String) {
-                valid = true;
-            }
-            break;
-        case &apos;xs:dateTime&apos;: // test for exact match to ISO8601
-            if (new Date(test).toISOString() === test) {
-                valid = true;
-            }
-            break;
-        default:
-            console.log(`** isType: dont know how to handle type ${type}, hope its good`);
-            valid = true;
-    }
-    if (valid &amp;&amp; definition &amp;&amp; definition.values &amp;&amp; !definition.values.includes(test)) {
-        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
-    }
-    return valid;
-};
-/**
- * The &quot;validate&quot; step of &quot;validateAndTransform&quot; will happen here. See discussion here:
- * https://github.com/ericblade/mws-advanced/pull/20
- *
- * @private
- * @param {any} test
- * @param {any} definition
- * @returns
- */
-function validate(test, definition) {
-    let validOrderId = false;
-    const re = /\d{3}-\d{7}-\d{3}/g;
-    if (re.test(test) &amp;&amp; definition.stringFormat === &apos;amazonOrderId&apos;) {
-        validOrderId = true;
-    }
-    return validOrderId;
-}
+  
+  
+  <div class="flat-list" data-ice="extendsChain"><h4>Extends:</h4><div><span>extError</span> &#x2192; ServiceError</div></div>
+  
+  
+  
+  
+  
+  
 
-/**
- * Used to both validate and transform &quot;normal&quot; javascript parameters (such as regular strings,
- * arrays, object hashes, and Date objects) into something that the underlying MWS system can
- * understand.
- *
- * @private
- * @param {any} valid
- * @param {any} options
- * @returns
- */
-const validateAndTransformParameters = (valid, options) =&gt; {
-    if (!options) {
-        return {};
-    }
-    if (!valid) {
-        console.warn(&apos;**** no validation parameters passed to validateAndTransform, no checking will be performed&apos;);
-        return options;
-    }
+  
+  
+  <div class="description" data-ice="description"><p>Thrown when an Error response comes from the Service (not a mws-simple.ServerError though)</p>
+</div>
+  
 
-    const newOptions = {};
-    // check for unknown parameters
-    Object.keys(options).forEach((k) =&gt; {
-        if (!valid[k]) {
-            throw new errors.ValidationError(`Unknown parameter ${k}`);
-        }
-    });
-    // check for required, list, and type (inside and outside of list)
-    // transform lists into the expected keys at the MWS side.
-    // ie key AmazonOrderId becomes AmazonOrderId.Id.{index}
-    Object.keys(valid).forEach((k) =&gt; {
-        const v = valid[k];
-        const o = options[k];
+  
 
-        // if required and not found, throw
-        if (v.required &amp;&amp; !o) {
-            throw new errors.ValidationError(`Required parameter ${k} missing`);
-        }
-        // transform Date objects into ISO strings
-        if (v.type === &apos;xs:dateTime&apos; &amp;&amp; o instanceof Date) {
-            newOptions[k] = o.toISOString();
-        } else if (v.list &amp;&amp; o) { // transform lists
-            if (!Array.isArray(o)) {
-                throw new errors.ValidationError(`Parameter ${k} expected an array`);
-            }
-            if (v.listMax &amp;&amp; o.length &gt; v.listMax) {
-                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
-            }
-            if (!o.every(val =&gt; isType(v.type, val, v))) {
-                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
-            }
-            o.forEach((item, index) =&gt; {
-                newOptions[`${v.list}.${index + 1}`] = item;
-            });
-        } else { // if not already handled, then run it through isType
-            if (v &amp;&amp; o &amp;&amp; !isType(v.type, o, v)) {
-                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
-            }
-            if (k &amp;&amp; o) {
-                newOptions[k] = o;
-            }
-        }
-    });
-    return newOptions;
-};
+  
 
-module.exports = {
-    isType,
-    validate,
-    validateAndTransformParameters,
-};
-</code></pre>
+  
+
+  
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 </div>
 

--- a/docs/class/lib/errors.js~ValidationError.html
+++ b/docs/class/lib/errors.js~ValidationError.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/validation.js | mws-advanced</title>
+  <title data-ice="title">ValidationError | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -72,173 +72,58 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/validation.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
+<div class="content" data-ice="content"><div class="header-notice">
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {ValidationError} from &apos;<span><a href="file/lib/errors.js.html#lineNumber33">mws-advanced/lib/errors.js</a></span>&apos;</code></pre></div>
+  <span data-ice="access">public</span>
+  <span data-ice="kind">class</span>
+  
+  
+  
+  <span data-ice="source">| <span><a href="file/lib/errors.js.html#lineNumber33">source</a></span></span>
+</div>
 
-// TODO: testing indicates some weirdness in this call. It throws for things that are outside of
-// ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
-// does not throw for basic type incompatibility, relying on it&apos;s caller to throw. Should this throw
-// on all errors, or should it not throw on any errors? It&apos;s a lot easier to determine the *reason*
-// for the throw here, so I lean towards fixing this to throw an error for all invalid things. For
-// right now, I&apos;m going to leave it exactly as is, because there&apos;s always a throw at the end user,
-// but this makes unit testing weird.
+<div class="self-detail detail">
+  <h1 data-ice="name">ValidationError</h1>
 
-// we expect xs:dateTime to come in as a ISO string. This is a little confusing because the
-// consumer, validateAndTransform allows Date objects as input.
-/* eslint-disable no-param-reassign */
-/**
- *
- *
- * @param {string} type - type of integer to validate (xs:int, xs:positiveInteger, etc)
- * @param {any} test - value to test
- * @param {object} minmax - minimum and maximum values to test for
- * @param {integer} minmax.minValue - minimum value to test for
- * @param {integer} minmax.maxValue - maximum value to test for
- */
-const validateInteger = (type, test, { minValue, maxValue } = { }) =&gt; {
-    if (minValue === undefined) {
-        if (type === &apos;xs:positiveInteger&apos;) minValue = 1;
-        else if (type === &apos;xs:nonNegativeInteger&apos;) minValue = 0;
-        else minValue = -2147483658;
-    }
-    if (maxValue === undefined) {
-        maxValue = 2147483647;
-    }
-    const newTest = parseInt(test, 10);
-    // eslint-disable-next-line eqeqeq
-    const valid = test == newTest &amp;&amp; (minValue == null || newTest &gt;= minValue) &amp;&amp; (maxValue == null || newTest &lt;= maxValue);
-    if (!valid) {
-        throw new errors.ValidationError(`Expected type ${type} ${minValue} &lt;= ${test} &lt;= ${maxValue}`);
-    }
-    return valid;
-};
+  
 
-/**
- * Tests if an item belongs to a given type, and validates values and other stuff.
- * This function is currently overloaded to do too much. Sorry. The end consumer of *this* function,
- * validateAndTransform, is handling crazier stuff.
- * @private
- * @param {string} type data type referenced from MWS documentation (ie, &apos;xs:positiveInteger&apos;)
- * @param {any} test data to test against the given type
- * @param {any} definition validation definition (see lib/endpoints)
- * @returns Boolean true if correct type AND valid, false if not. Throws on many errors.
- */
-const isType = (type, test, definition) =&gt; {
-    let valid = false;
-    switch (type) {
-        case &apos;xs:int&apos;:
-        case &apos;xs:positiveInteger&apos;: // fallthrough from xs:int intentional
-        case &apos;xs:nonNegativeInteger&apos;: // fallthrough from xs:positiveInteger intentional
-            valid = validateInteger(type, test, definition);
-            break;
-        case &apos;xs:string&apos;:
-            if (typeof test === &apos;string&apos; || test instanceof String) {
-                valid = true;
-            }
-            break;
-        case &apos;xs:dateTime&apos;: // test for exact match to ISO8601
-            if (new Date(test).toISOString() === test) {
-                valid = true;
-            }
-            break;
-        default:
-            console.log(`** isType: dont know how to handle type ${type}, hope its good`);
-            valid = true;
-    }
-    if (valid &amp;&amp; definition &amp;&amp; definition.values &amp;&amp; !definition.values.includes(test)) {
-        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
-    }
-    return valid;
-};
-/**
- * The &quot;validate&quot; step of &quot;validateAndTransform&quot; will happen here. See discussion here:
- * https://github.com/ericblade/mws-advanced/pull/20
- *
- * @private
- * @param {any} test
- * @param {any} definition
- * @returns
- */
-function validate(test, definition) {
-    let validOrderId = false;
-    const re = /\d{3}-\d{7}-\d{3}/g;
-    if (re.test(test) &amp;&amp; definition.stringFormat === &apos;amazonOrderId&apos;) {
-        validOrderId = true;
-    }
-    return validOrderId;
-}
+  
+  
+  <div class="flat-list" data-ice="extendsChain"><h4>Extends:</h4><div><span>extError</span> &#x2192; ValidationError</div></div>
+  
+  
+  
+  
+  
+  
 
-/**
- * Used to both validate and transform &quot;normal&quot; javascript parameters (such as regular strings,
- * arrays, object hashes, and Date objects) into something that the underlying MWS system can
- * understand.
- *
- * @private
- * @param {any} valid
- * @param {any} options
- * @returns
- */
-const validateAndTransformParameters = (valid, options) =&gt; {
-    if (!options) {
-        return {};
-    }
-    if (!valid) {
-        console.warn(&apos;**** no validation parameters passed to validateAndTransform, no checking will be performed&apos;);
-        return options;
-    }
+  
+  
+  <div class="description" data-ice="description"><p>Thrown when parameters fail validation locally, before being sent to MWS</p>
+</div>
+  
 
-    const newOptions = {};
-    // check for unknown parameters
-    Object.keys(options).forEach((k) =&gt; {
-        if (!valid[k]) {
-            throw new errors.ValidationError(`Unknown parameter ${k}`);
-        }
-    });
-    // check for required, list, and type (inside and outside of list)
-    // transform lists into the expected keys at the MWS side.
-    // ie key AmazonOrderId becomes AmazonOrderId.Id.{index}
-    Object.keys(valid).forEach((k) =&gt; {
-        const v = valid[k];
-        const o = options[k];
+  
 
-        // if required and not found, throw
-        if (v.required &amp;&amp; !o) {
-            throw new errors.ValidationError(`Required parameter ${k} missing`);
-        }
-        // transform Date objects into ISO strings
-        if (v.type === &apos;xs:dateTime&apos; &amp;&amp; o instanceof Date) {
-            newOptions[k] = o.toISOString();
-        } else if (v.list &amp;&amp; o) { // transform lists
-            if (!Array.isArray(o)) {
-                throw new errors.ValidationError(`Parameter ${k} expected an array`);
-            }
-            if (v.listMax &amp;&amp; o.length &gt; v.listMax) {
-                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
-            }
-            if (!o.every(val =&gt; isType(v.type, val, v))) {
-                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
-            }
-            o.forEach((item, index) =&gt; {
-                newOptions[`${v.list}.${index + 1}`] = item;
-            });
-        } else { // if not already handled, then run it through isType
-            if (v &amp;&amp; o &amp;&amp; !isType(v.type, o, v)) {
-                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
-            }
-            if (k &amp;&amp; o) {
-                newOptions[k] = o;
-            }
-        }
-    });
-    return newOptions;
-};
+  
 
-module.exports = {
-    isType,
-    validate,
-    validateAndTransformParameters,
-};
-</code></pre>
+  
+
+  
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 </div>
 

--- a/docs/file/lib/callEndpoint.js.html
+++ b/docs/file/lib/callEndpoint.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -73,6 +77,8 @@
 const { MWS_ENDPOINTS } = require(&apos;./constants&apos;);
 const sleep = require(&apos;./util/sleep&apos;);
 const fs = require(&apos;fs&apos;);
+
+const errors = require(&apos;./errors.js&apos;);
 
 /*
  * TODO: split the &quot;init&quot; function out of the &quot;callEndpoint&quot; file, difficulty: callEndpoint
@@ -197,7 +203,7 @@ const requestPromise = (requestData, opt = {}) =&gt;
 const callEndpoint = async (name, callOptions = {}, opt = {}) =&gt; {
     const endpoint = endpoints[name];
     if (!endpoint) {
-        throw new Error(&apos;No endpoint name supplied to callEndpoint&apos;);
+        throw new errors.InvalidUsage(&apos;No endpoint name supplied to callEndpoint&apos;);
     }
 
     const newOptions = endpoint.params ?
@@ -228,32 +234,34 @@ const callEndpoint = async (name, callOptions = {}, opt = {}) =&gt; {
         }
         return digResult;
     } catch (err) {
-        if (err.code === 503) {
-            console.warn(&apos;***** Error 503 .. throttling?&apos;, name);
-            let ms = 2000;
-            if (!endpoint.throttle) {
-                console.warn(`***** throttle information missing for API ${name}`);
-                console.warn(&apos;***** &apos;, JSON.stringify(endpoint));
-            } else {
-                // restoreRate = how many you get back in a minute of time. there&apos;s an assumption here
-                // that you&apos;re spamming a lot of requests if you&apos;re hitting throttling, and this
-                // throttle management system is first version, here -- so we&apos;re going to throttle it
-                // not to the minimum possible time frame, but to the length of time that it will take
-                // to restore your entire maxInFlight -- assuming you&apos;re probably going to hit the max
-                // again as soon as we start letting more requests in.
+        if (err instanceof MWS.ServerError) {
+            if (err.code === 503) {
+                console.warn(&apos;***** Error 503 .. throttling?&apos;, name);
+                let ms = 2000;
+                if (!endpoint.throttle) {
+                    console.warn(`***** throttle information missing for API ${name}`);
+                    console.warn(&apos;***** &apos;, JSON.stringify(endpoint));
+                } else {
+                    // restoreRate = how many you get back in a minute of time. there&apos;s an assumption here
+                    // that you&apos;re spamming a lot of requests if you&apos;re hitting throttling, and this
+                    // throttle management system is first version, here -- so we&apos;re going to throttle it
+                    // not to the minimum possible time frame, but to the length of time that it will take
+                    // to restore your entire maxInFlight -- assuming you&apos;re probably going to hit the max
+                    // again as soon as we start letting more requests in.
 
-                // ultimately, an upgraded version of this throttling handler would keep track of how
-                // many of every request are in flight, and try to throttle it to the minimum amount
-                // of time that you can go, automatically throttling future calls without having to
-                // even encounter the 503 from the server.
+                    // ultimately, an upgraded version of this throttling handler would keep track of how
+                    // many of every request are in flight, and try to throttle it to the minimum amount
+                    // of time that you can go, automatically throttling future calls without having to
+                    // even encounter the 503 from the server.
 
-                // that day is not today.  it might be tomorrow. maybe next weekend. i don&apos;t know. :-)
-                const restoreMaxInFlightMin = (endpoint.throttle.maxInFlight / endpoint.throttle.restoreRate) * (callOptions.IdList ? callOptions.IdList.length : 1);
-                ms = (restoreMaxInFlightMin * 60 * 1000) + 100;
+                    // that day is not today.  it might be tomorrow. maybe next weekend. i don&apos;t know. :-)
+                    const restoreMaxInFlightMin = (endpoint.throttle.maxInFlight / endpoint.throttle.restoreRate) * (callOptions.IdList ? callOptions.IdList.length : 1);
+                    ms = (restoreMaxInFlightMin * 60 * 1000) + 100;
+                }
+                console.warn(`***** trying again in ${ms}ms`);
+                await sleep(ms + 100);
+                return callEndpoint(name, callOptions, opt);
             }
-            console.warn(`***** trying again in ${ms}ms`);
-            await sleep(ms + 100);
-            return callEndpoint(name, callOptions, opt);
         }
         throw err;
     }

--- a/docs/file/lib/constants.js.html
+++ b/docs/file/lib/constants.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/dig-response-result.js.html
+++ b/docs/file/lib/dig-response-result.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -69,7 +73,9 @@
 </nav>
 
 <div class="content" data-ice="content"><h1 data-ice="title">lib/dig-response-result.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">/**
+<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
+
+/**
  * Return data.${name}Response.${name}Result if available, otherwise return data
  * Convenience method to avoid having to do that in virtually every single response
  * @private
@@ -79,7 +85,7 @@
  */
 const digResponseResult = (name, data) =&gt; {
     if (data.ErrorResponse) {
-        throw new Error(JSON.stringify(data.ErrorResponse));
+        throw new errors.ServiceError(JSON.stringify(data.ErrorResponse));
     }
     if (data[`${name}Response`]) {
         return data[`${name}Response`][`${name}Result`];

--- a/docs/file/lib/endpoints/constants.js.html
+++ b/docs/file/lib/endpoints/constants.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/endpoints-utils.js.html
+++ b/docs/file/lib/endpoints/endpoints-utils.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/feeds.js.html
+++ b/docs/file/lib/endpoints/feeds.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/finances.js.html
+++ b/docs/file/lib/endpoints/finances.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/inbound.js.html
+++ b/docs/file/lib/endpoints/inbound.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/index.js.html
+++ b/docs/file/lib/endpoints/index.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/inventory.js.html
+++ b/docs/file/lib/endpoints/inventory.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/merch-fulfillment.js.html
+++ b/docs/file/lib/endpoints/merch-fulfillment.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/orders.js.html
+++ b/docs/file/lib/endpoints/orders.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/outbound.js.html
+++ b/docs/file/lib/endpoints/outbound.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/products.js.html
+++ b/docs/file/lib/endpoints/products.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/reports.js.html
+++ b/docs/file/lib/endpoints/reports.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/endpoints/sellers.js.html
+++ b/docs/file/lib/endpoints/sellers.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/errors.js.html
+++ b/docs/file/lib/errors.js.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/validation.js | mws-advanced</title>
+  <title data-ice="title">lib/errors.js | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -72,171 +72,46 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/validation.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const errors = require(&apos;./errors&apos;);
-
-// TODO: testing indicates some weirdness in this call. It throws for things that are outside of
-// ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
-// does not throw for basic type incompatibility, relying on it&apos;s caller to throw. Should this throw
-// on all errors, or should it not throw on any errors? It&apos;s a lot easier to determine the *reason*
-// for the throw here, so I lean towards fixing this to throw an error for all invalid things. For
-// right now, I&apos;m going to leave it exactly as is, because there&apos;s always a throw at the end user,
-// but this makes unit testing weird.
-
-// we expect xs:dateTime to come in as a ISO string. This is a little confusing because the
-// consumer, validateAndTransform allows Date objects as input.
-/* eslint-disable no-param-reassign */
-/**
- *
- *
- * @param {string} type - type of integer to validate (xs:int, xs:positiveInteger, etc)
- * @param {any} test - value to test
- * @param {object} minmax - minimum and maximum values to test for
- * @param {integer} minmax.minValue - minimum value to test for
- * @param {integer} minmax.maxValue - maximum value to test for
- */
-const validateInteger = (type, test, { minValue, maxValue } = { }) =&gt; {
-    if (minValue === undefined) {
-        if (type === &apos;xs:positiveInteger&apos;) minValue = 1;
-        else if (type === &apos;xs:nonNegativeInteger&apos;) minValue = 0;
-        else minValue = -2147483658;
-    }
-    if (maxValue === undefined) {
-        maxValue = 2147483647;
-    }
-    const newTest = parseInt(test, 10);
-    // eslint-disable-next-line eqeqeq
-    const valid = test == newTest &amp;&amp; (minValue == null || newTest &gt;= minValue) &amp;&amp; (maxValue == null || newTest &lt;= maxValue);
-    if (!valid) {
-        throw new errors.ValidationError(`Expected type ${type} ${minValue} &lt;= ${test} &lt;= ${maxValue}`);
-    }
-    return valid;
-};
+<div class="content" data-ice="content"><h1 data-ice="title">lib/errors.js</h1>
+<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const extError = require(&apos;es6-error&apos;);
 
 /**
- * Tests if an item belongs to a given type, and validates values and other stuff.
- * This function is currently overloaded to do too much. Sorry. The end consumer of *this* function,
- * validateAndTransform, is handling crazier stuff.
- * @private
- * @param {string} type data type referenced from MWS documentation (ie, &apos;xs:positiveInteger&apos;)
- * @param {any} test data to test against the given type
- * @param {any} definition validation definition (see lib/endpoints)
- * @returns Boolean true if correct type AND valid, false if not. Throws on many errors.
- */
-const isType = (type, test, definition) =&gt; {
-    let valid = false;
-    switch (type) {
-        case &apos;xs:int&apos;:
-        case &apos;xs:positiveInteger&apos;: // fallthrough from xs:int intentional
-        case &apos;xs:nonNegativeInteger&apos;: // fallthrough from xs:positiveInteger intentional
-            valid = validateInteger(type, test, definition);
-            break;
-        case &apos;xs:string&apos;:
-            if (typeof test === &apos;string&apos; || test instanceof String) {
-                valid = true;
-            }
-            break;
-        case &apos;xs:dateTime&apos;: // test for exact match to ISO8601
-            if (new Date(test).toISOString() === test) {
-                valid = true;
-            }
-            break;
-        default:
-            console.log(`** isType: dont know how to handle type ${type}, hope its good`);
-            valid = true;
-    }
-    if (valid &amp;&amp; definition &amp;&amp; definition.values &amp;&amp; !definition.values.includes(test)) {
-        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
-    }
-    return valid;
-};
-/**
- * The &quot;validate&quot; step of &quot;validateAndTransform&quot; will happen here. See discussion here:
- * https://github.com/ericblade/mws-advanced/pull/20
+ * Thrown when completely Invalid Parameters are given and we have no way of making sense of them
  *
- * @private
- * @param {any} test
- * @param {any} definition
- * @returns
+ * @class InvalidUsage
+ * @extends {Error}
  */
-function validate(test, definition) {
-    let validOrderId = false;
-    const re = /\d{3}-\d{7}-\d{3}/g;
-    if (re.test(test) &amp;&amp; definition.stringFormat === &apos;amazonOrderId&apos;) {
-        validOrderId = true;
-    }
-    return validOrderId;
-}
+ class InvalidUsage extends extError {}
 
 /**
- * Used to both validate and transform &quot;normal&quot; javascript parameters (such as regular strings,
- * arrays, object hashes, and Date objects) into something that the underlying MWS system can
- * understand.
+ * Thrown when an Error response comes from the Service (not a mws-simple.ServerError though)
  *
- * @private
- * @param {any} valid
- * @param {any} options
- * @returns
+ * @class ServiceError
+ * @extends {extError}
  */
-const validateAndTransformParameters = (valid, options) =&gt; {
-    if (!options) {
-        return {};
-    }
-    if (!valid) {
-        console.warn(&apos;**** no validation parameters passed to validateAndTransform, no checking will be performed&apos;);
-        return options;
-    }
+class ServiceError extends extError {}
 
-    const newOptions = {};
-    // check for unknown parameters
-    Object.keys(options).forEach((k) =&gt; {
-        if (!valid[k]) {
-            throw new errors.ValidationError(`Unknown parameter ${k}`);
-        }
-    });
-    // check for required, list, and type (inside and outside of list)
-    // transform lists into the expected keys at the MWS side.
-    // ie key AmazonOrderId becomes AmazonOrderId.Id.{index}
-    Object.keys(valid).forEach((k) =&gt; {
-        const v = valid[k];
-        const o = options[k];
+/**
+ * Thrown when a request is cancelled by MWS -- we have no way of knowing automatically if we should retry or not
+ *
+ * @class RequestCancelled
+ * @extends {extError}
+ */
+class RequestCancelled extends extError {}
 
-        // if required and not found, throw
-        if (v.required &amp;&amp; !o) {
-            throw new errors.ValidationError(`Required parameter ${k} missing`);
-        }
-        // transform Date objects into ISO strings
-        if (v.type === &apos;xs:dateTime&apos; &amp;&amp; o instanceof Date) {
-            newOptions[k] = o.toISOString();
-        } else if (v.list &amp;&amp; o) { // transform lists
-            if (!Array.isArray(o)) {
-                throw new errors.ValidationError(`Parameter ${k} expected an array`);
-            }
-            if (v.listMax &amp;&amp; o.length &gt; v.listMax) {
-                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
-            }
-            if (!o.every(val =&gt; isType(v.type, val, v))) {
-                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
-            }
-            o.forEach((item, index) =&gt; {
-                newOptions[`${v.list}.${index + 1}`] = item;
-            });
-        } else { // if not already handled, then run it through isType
-            if (v &amp;&amp; o &amp;&amp; !isType(v.type, o, v)) {
-                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
-            }
-            if (k &amp;&amp; o) {
-                newOptions[k] = o;
-            }
-        }
-    });
-    return newOptions;
-};
+/**
+ * Thrown when parameters fail validation locally, before being sent to MWS
+ *
+ * @class ValidationError
+ * @extends {extError}
+ */
+class ValidationError extends extError {}
 
 module.exports = {
-    isType,
-    validate,
-    validateAndTransformParameters,
+    InvalidUsage,
+    RequestCancelled,
+    ServiceError,
+    ValidationError,
 };
 </code></pre>
 

--- a/docs/file/lib/flatten-result.js.html
+++ b/docs/file/lib/flatten-result.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/get-lowest-priced-offers.js.html
+++ b/docs/file/lib/get-lowest-priced-offers.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -211,7 +215,7 @@ const reformatBuyBoxPrice = bb =&gt; ({
  * @return {OfferSummary}
  */
 const reformatSummary = (summary) =&gt; {
-    const buyBoxPrices = forceArray(summary.BuyBoxPrices.BuyBoxPrice);
+    const buyBoxPrices = forceArray(summary.BuyBoxPrices);
 
     const ret = {};
     ret.totalOfferCount = parseInt(summary.TotalOfferCount, 10);

--- a/docs/file/lib/get-marketplaces.js.html
+++ b/docs/file/lib/get-marketplaces.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/get-matching-product.js.html
+++ b/docs/file/lib/get-matching-product.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -71,6 +75,7 @@
 <div class="content" data-ice="content"><h1 data-ice="title">lib/get-matching-product.js</h1>
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const { callEndpoint } = require(&apos;./callEndpoint&apos;);
 const { forceArray, transformKey, transformObjectKeys } = require(&apos;./util/transformers&apos;);
+const errors = require(&apos;./errors&apos;);
 
 /**
  * remove a string pattern from a string
@@ -103,7 +108,7 @@ const transformAttributeSetKey = k =&gt; transformKey(removeFromString(k)(/^ns2:
 const getMatchingProductForId = async (options) =&gt; {
     const result = await callEndpoint(&apos;GetMatchingProductForId&apos;, options);
     if (result.Error) {
-        throw new Error(JSON.stringify(result.Error.Message));
+        throw new errors.ServiceError(result.Error.Message);
     }
     // for a single return, flattenResult will drop this to an object, which is not desireable
     // in this particular case.

--- a/docs/file/lib/index.js.html
+++ b/docs/file/lib/index.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/list-financial-events.js.html
+++ b/docs/file/lib/list-financial-events.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/list-inventory-supply.js.html
+++ b/docs/file/lib/list-inventory-supply.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/list-order-items.js.html
+++ b/docs/file/lib/list-order-items.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/list-orders.js.html
+++ b/docs/file/lib/list-orders.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/file/lib/reports.js.html
+++ b/docs/file/lib/reports.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -75,6 +79,8 @@
 
 const { promisify } = require(&apos;util&apos;);
 const fs = require(&apos;fs&apos;);
+
+const errors = require(&apos;./errors&apos;);
 
 /**
  * Promisified version of fs.writeFile
@@ -282,7 +288,7 @@ const requestAndDownloadReport = async (ReportType, file, reportParams = {}) =&g
                 case &apos;_DONE_&apos;:
                     return report;
                 case &apos;_DONE_NO_DATA_&apos;:
-                    return {};
+                    return null;
                 default:
                     console.log(`-- unknown status retry in 45 sec: ${report.ReportProcessingStatus}`, report);
                     await sleep(45000);
@@ -300,9 +306,13 @@ const requestAndDownloadReport = async (ReportType, file, reportParams = {}) =&g
     const reportRequestId = request.ReportRequestId;
     await sleep(20000); // some requests may be available quickly, check after 20 sec
     const reportCheck = await checkReportComplete(reportRequestId);
+    if (reportCheck.cancelled) {
+        console.warn(&apos;******** report request cancelled by server&apos;, ReportType);
+        throw new errors.RequestCancelled(&apos;Report cancelled by server&apos;);
+    }
     let ReportId = reportCheck.GeneratedReportId;
 
-    // TODO: Some reports do not provide a GeneratedReportId and we need to call GetReportList to find the identifier!
+    // When no ReportId is received, then call getReportList to find it.
     if (!ReportId) {
         const reportList = await getReportList({
             ReportTypeList: [ReportType],

--- a/docs/file/lib/util/sleep.js.html
+++ b/docs/file/lib/util/sleep.js.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/function/index.html
+++ b/docs/function/index.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -565,11 +569,11 @@ Many optional parameters may be required by MWS! Read <a href="https://docs.deve
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber126">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber128">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber126">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {callEndpoint} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber128">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Call a known endpoint at MWS, returning the raw data from the function. Parameters are
@@ -844,11 +848,11 @@ transformed and validated according to the rules defined in lib/endpoints</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/get-matching-product.js.html#lineNumber32">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/get-matching-product.js.html#lineNumber33">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getMatchingProductForId} from &apos;<span><a href="file/lib/get-matching-product.js.html#lineNumber32">mws-advanced/lib/get-matching-product.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getMatchingProductForId} from &apos;<span><a href="file/lib/get-matching-product.js.html#lineNumber33">mws-advanced/lib/get-matching-product.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Returns a list of products and their attributes, based on a list of ASIN, GCID, SellerSKU, UPC,
@@ -939,11 +943,11 @@ EAN, ISBN, or JAN values</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber99">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber101">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber99">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber101">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Returns the contents of a report</p>
@@ -1020,11 +1024,11 @@ EAN, ISBN, or JAN values</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber107">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber109">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportList} from &apos;<span><a href="file/lib/reports.js.html#lineNumber107">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportList} from &apos;<span><a href="file/lib/reports.js.html#lineNumber109">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>TODO: write documentation for getReportList</p>
@@ -1093,11 +1097,11 @@ EAN, ISBN, or JAN values</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber142">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber144">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportListAll} from &apos;<span><a href="file/lib/reports.js.html#lineNumber142">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportListAll} from &apos;<span><a href="file/lib/reports.js.html#lineNumber144">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>TODO: write documentation for getReportListAll (or see comment on getReportListByNextToken)</p>
@@ -1166,11 +1170,11 @@ EAN, ISBN, or JAN values</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber126">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber128">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportListByNextToken} from &apos;<span><a href="file/lib/reports.js.html#lineNumber126">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportListByNextToken} from &apos;<span><a href="file/lib/reports.js.html#lineNumber128">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>TODO: write documentation for getReportListByNextToken
@@ -1240,11 +1244,11 @@ EAN, ISBN, or JAN values</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber86">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber88">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportRequestList} from &apos;<span><a href="file/lib/reports.js.html#lineNumber86">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {getReportRequestList} from &apos;<span><a href="file/lib/reports.js.html#lineNumber88">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Returns a list of report requests that you can use to get the ReportRequestId for a report
@@ -1360,11 +1364,11 @@ has been processed.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber40">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/callEndpoint.js.html#lineNumber42">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber40">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {init} from &apos;<span><a href="file/lib/callEndpoint.js.html#lineNumber42">mws-advanced/lib/callEndpoint.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Initialize mws-advanced with your MWS access keys, merchantId, optionally authtoken, host, port
@@ -1952,11 +1956,11 @@ If you are having trouble, see the official parameter documentation above.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber194">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber196">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {requestAndDownloadReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber194">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {requestAndDownloadReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber196">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>TODO: Document requestAndDownloadReport</p>
@@ -2037,11 +2041,11 @@ If you are having trouble, see the official parameter documentation above.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber46">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/reports.js.html#lineNumber48">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {requestReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber46">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {requestReport} from &apos;<span><a href="file/lib/reports.js.html#lineNumber48">mws-advanced/lib/reports.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Request a report from MWS

--- a/docs/identifiers.html
+++ b/docs/identifiers.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -80,6 +84,122 @@
   <tbody>
   
   <tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-class">C</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Thrown when completely Invalid Parameters are given and we have no way of making sense of them</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-class">C</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Thrown when a request is cancelled by MWS -- we have no way of knowing automatically if we should retry or not</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-class">C</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Thrown when an Error response comes from the Service (not a mws-simple.ServerError though)</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-class">C</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Thrown when parameters fail validation locally, before being sent to MWS</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
     <td>
       <span class="access" data-ice="access">public</span>
       

--- a/docs/script/search_index.js
+++ b/docs/script/search_index.js
@@ -1,5 +1,11 @@
 window.esdocSearchIndex = [
   [
+    "mws-advanced/lib/errors.js~invalidusage",
+    "class/lib/errors.js~InvalidUsage.html",
+    "<span>InvalidUsage</span> <span class=\"search-result-import-path\">mws-advanced/lib/errors.js</span>",
+    "class"
+  ],
+  [
     "mws-advanced/lib/constants.js~mws_endpoints",
     "variable/index.html#static-variable-MWS_ENDPOINTS",
     "<span>MWS_ENDPOINTS</span> <span class=\"search-result-import-path\">mws-advanced/lib/constants.js</span>",
@@ -22,6 +28,24 @@ window.esdocSearchIndex = [
     "variable/index.html#static-variable-REQUEST_REPORT_TYPES",
     "<span>REQUEST_REPORT_TYPES</span> <span class=\"search-result-import-path\">mws-advanced/lib/endpoints/constants.js</span>",
     "variable"
+  ],
+  [
+    "mws-advanced/lib/errors.js~requestcancelled",
+    "class/lib/errors.js~RequestCancelled.html",
+    "<span>RequestCancelled</span> <span class=\"search-result-import-path\">mws-advanced/lib/errors.js</span>",
+    "class"
+  ],
+  [
+    "mws-advanced/lib/errors.js~serviceerror",
+    "class/lib/errors.js~ServiceError.html",
+    "<span>ServiceError</span> <span class=\"search-result-import-path\">mws-advanced/lib/errors.js</span>",
+    "class"
+  ],
+  [
+    "mws-advanced/lib/errors.js~validationerror",
+    "class/lib/errors.js~ValidationError.html",
+    "<span>ValidationError</span> <span class=\"search-result-import-path\">mws-advanced/lib/errors.js</span>",
+    "class"
   ],
   [
     "mws-advanced/lib/callendpoint.js~callendpoint",
@@ -495,6 +519,12 @@ window.esdocSearchIndex = [
     "lib/endpoints/sellers.js",
     "file/lib/endpoints/sellers.js.html",
     "lib/endpoints/sellers.js",
+    "file"
+  ],
+  [
+    "lib/errors.js",
+    "file/lib/errors.js.html",
+    "lib/errors.js",
     "file"
   ],
   [

--- a/docs/source.html
+++ b/docs/source.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>
@@ -68,7 +72,7 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">53/92</span></h1>
+<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">58/97</span></h1>
 
 <table class="files-summary" data-ice="files" data-use-coverage="true">
   <thead>
@@ -88,9 +92,9 @@
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span>
 <span><a href="function/index.html#static-function-init">init</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">8367 byte</td>
-      <td style="display: none;" data-ice="lines">194</td>
-      <td style="display: none;" data-ice="updated">2018-02-06 06:18:26 (UTC)</td>
+      <td style="display: none;" data-ice="size">8581 byte</td>
+      <td style="display: none;" data-ice="lines">198</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 21:10:11 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/constants.js.html">lib/constants.js</a></span></td>
@@ -99,15 +103,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
       <td style="display: none;" data-ice="size">1485 byte</td>
       <td style="display: none;" data-ice="lines">42</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/dig-response-result.js.html">lib/dig-response-result.js</a></span></td>
       <td data-ice="identifier" class="identifiers">-</td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
-      <td style="display: none;" data-ice="size">614 byte</td>
-      <td style="display: none;" data-ice="lines">21</td>
-      <td style="display: none;" data-ice="updated">2017-12-06 07:09:20 (UTC)</td>
+      <td style="display: none;" data-ice="size">667 byte</td>
+      <td style="display: none;" data-ice="lines">23</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 19:56:03 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/constants.js.html">lib/endpoints/constants.js</a></span></td>
@@ -116,7 +120,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
       <td style="display: none;" data-ice="size">4992 byte</td>
       <td style="display: none;" data-ice="lines">145</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 21:22:28 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/endpoints-utils.js.html">lib/endpoints/endpoints-utils.js</a></span></td>
@@ -124,7 +128,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">1388 byte</td>
       <td style="display: none;" data-ice="lines">35</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 07:36:00 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/feeds.js.html#errorLines=10,11,13,15">lib/endpoints/feeds.js</a></span></td>
@@ -132,7 +136,7 @@
       <td class="coverage"><span data-ice="coverage">20 %</span><span data-ice="coverageCount" class="coverage-count">1/5</span></td>
       <td style="display: none;" data-ice="size">686 byte</td>
       <td style="display: none;" data-ice="lines">33</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 10:06:41 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 21:22:27 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/finances.js.html#errorLines=15,3,5,7">lib/endpoints/finances.js</a></span></td>
@@ -140,7 +144,7 @@
       <td class="coverage"><span data-ice="coverage">20 %</span><span data-ice="coverageCount" class="coverage-count">1/5</span></td>
       <td style="display: none;" data-ice="size">1743 byte</td>
       <td style="display: none;" data-ice="lines">67</td>
-      <td style="display: none;" data-ice="updated">2018-02-06 06:30:49 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-03 18:55:19 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/inbound.js.html#errorLines=4,6,8">lib/endpoints/inbound.js</a></span></td>
@@ -148,7 +152,7 @@
       <td class="coverage"><span data-ice="coverage">25 %</span><span data-ice="coverageCount" class="coverage-count">1/4</span></td>
       <td style="display: none;" data-ice="size">1037 byte</td>
       <td style="display: none;" data-ice="lines">44</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/index.js.html">lib/endpoints/index.js</a></span></td>
@@ -156,7 +160,7 @@
       <td class="coverage"><span data-ice="coverage">-</span></td>
       <td style="display: none;" data-ice="size">901 byte</td>
       <td style="display: none;" data-ice="lines">29</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 21:22:28 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/inventory.js.html#errorLines=13,3,5,7">lib/endpoints/inventory.js</a></span></td>
@@ -164,7 +168,7 @@
       <td class="coverage"><span data-ice="coverage">20 %</span><span data-ice="coverageCount" class="coverage-count">1/5</span></td>
       <td style="display: none;" data-ice="size">1548 byte</td>
       <td style="display: none;" data-ice="lines">63</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/merch-fulfillment.js.html#errorLines=3,5,7">lib/endpoints/merch-fulfillment.js</a></span></td>
@@ -172,7 +176,7 @@
       <td class="coverage"><span data-ice="coverage">25 %</span><span data-ice="coverageCount" class="coverage-count">1/4</span></td>
       <td style="display: none;" data-ice="size">452 byte</td>
       <td style="display: none;" data-ice="lines">25</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/orders.js.html#errorLines=10,19,5,6,8">lib/endpoints/orders.js</a></span></td>
@@ -180,7 +184,7 @@
       <td class="coverage"><span data-ice="coverage">16 %</span><span data-ice="coverageCount" class="coverage-count">1/6</span></td>
       <td style="display: none;" data-ice="size">7703 byte</td>
       <td style="display: none;" data-ice="lines">246</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 08:01:24 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/outbound.js.html#errorLines=3,5,7">lib/endpoints/outbound.js</a></span></td>
@@ -188,7 +192,7 @@
       <td class="coverage"><span data-ice="coverage">25 %</span><span data-ice="coverageCount" class="coverage-count">1/4</span></td>
       <td style="display: none;" data-ice="size">682 byte</td>
       <td style="display: none;" data-ice="lines">31</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/products.js.html#errorLines=25,3,5,7">lib/endpoints/products.js</a></span></td>
@@ -196,7 +200,7 @@
       <td class="coverage"><span data-ice="coverage">20 %</span><span data-ice="coverageCount" class="coverage-count">1/5</span></td>
       <td style="display: none;" data-ice="size">14696 byte</td>
       <td style="display: none;" data-ice="lines">496</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-03 23:14:34 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/reports.js.html#errorLines=10,12,29,7,8">lib/endpoints/reports.js</a></span></td>
@@ -204,7 +208,7 @@
       <td class="coverage"><span data-ice="coverage">16 %</span><span data-ice="coverageCount" class="coverage-count">1/6</span></td>
       <td style="display: none;" data-ice="size">14392 byte</td>
       <td style="display: none;" data-ice="lines">498</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 18:58:20 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/sellers.js.html#errorLines=12,3,5,7">lib/endpoints/sellers.js</a></span></td>
@@ -212,7 +216,18 @@
       <td class="coverage"><span data-ice="coverage">20 %</span><span data-ice="coverageCount" class="coverage-count">1/5</span></td>
       <td style="display: none;" data-ice="size">2829 byte</td>
       <td style="display: none;" data-ice="lines">109</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 18:03:14 (UTC)</td>
+    </tr>
+<tr data-ice="file">
+      <td data-ice="filePath"><span><a href="file/lib/errors.js.html">lib/errors.js</a></span></td>
+      <td data-ice="identifier" class="identifiers"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span>
+<span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span>
+<span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span>
+<span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></td>
+      <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
+      <td style="display: none;" data-ice="size">963 byte</td>
+      <td style="display: none;" data-ice="lines">40</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 21:14:49 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/flatten-result.js.html">lib/flatten-result.js</a></span></td>
@@ -220,15 +235,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">3/3</span></td>
       <td style="display: none;" data-ice="size">2729 byte</td>
       <td style="display: none;" data-ice="lines">65</td>
-      <td style="display: none;" data-ice="updated">2018-02-02 07:48:56 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-03 18:55:19 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/get-lowest-priced-offers.js.html">lib/get-lowest-priced-offers.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">6/6</span></td>
-      <td style="display: none;" data-ice="size">6300 byte</td>
+      <td style="display: none;" data-ice="size">6288 byte</td>
       <td style="display: none;" data-ice="lines">192</td>
-      <td style="display: none;" data-ice="updated">2018-02-06 06:46:34 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-03 18:55:19 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/get-marketplaces.js.html">lib/get-marketplaces.js</a></span></td>
@@ -236,15 +251,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">3223 byte</td>
       <td style="display: none;" data-ice="lines">73</td>
-      <td style="display: none;" data-ice="updated">2018-02-06 06:13:54 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-06 05:40:05 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/get-matching-product.js.html">lib/get-matching-product.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-getMatchingProductForId">getMatchingProductForId</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">3/3</span></td>
-      <td style="display: none;" data-ice="size">2128 byte</td>
-      <td style="display: none;" data-ice="lines">57</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="size">2163 byte</td>
+      <td style="display: none;" data-ice="lines">58</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 19:56:43 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/index.js.html">lib/index.js</a></span></td>
@@ -252,7 +267,7 @@
       <td class="coverage"><span data-ice="coverage">-</span></td>
       <td style="display: none;" data-ice="size">1445 byte</td>
       <td style="display: none;" data-ice="lines">45</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-05 01:02:46 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-financial-events.js.html">lib/list-financial-events.js</a></span></td>
@@ -260,7 +275,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">1413 byte</td>
       <td style="display: none;" data-ice="lines">31</td>
-      <td style="display: none;" data-ice="updated">2018-02-02 07:43:05 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-01 19:44:56 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-inventory-supply.js.html">lib/list-inventory-supply.js</a></span></td>
@@ -268,7 +283,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">1040 byte</td>
       <td style="display: none;" data-ice="lines">30</td>
-      <td style="display: none;" data-ice="updated">2018-01-01 09:59:24 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-01 15:50:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-order-items.js.html">lib/list-order-items.js</a></span></td>
@@ -276,7 +291,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">2197 byte</td>
       <td style="display: none;" data-ice="lines">56</td>
-      <td style="display: none;" data-ice="updated">2018-02-02 07:43:05 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-01 19:29:37 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-orders.js.html">lib/list-orders.js</a></span></td>
@@ -284,7 +299,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">2693 byte</td>
       <td style="display: none;" data-ice="lines">44</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-01-04 21:08:01 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/reports.js.html">lib/reports.js</a></span></td>
@@ -296,9 +311,9 @@
 <span><a href="function/index.html#static-function-requestAndDownloadReport">requestAndDownloadReport</a></span>
 <span><a href="function/index.html#static-function-requestReport">requestReport</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">8/8</span></td>
-      <td style="display: none;" data-ice="size">11490 byte</td>
-      <td style="display: none;" data-ice="lines">257</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="size">11682 byte</td>
+      <td style="display: none;" data-ice="lines">263</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 19:57:48 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/util/sleep.js.html">lib/util/sleep.js</a></span></td>
@@ -306,15 +321,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
       <td style="display: none;" data-ice="size">289 byte</td>
       <td style="display: none;" data-ice="lines">13</td>
-      <td style="display: none;" data-ice="updated">2018-02-07 14:13:45 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-02-06 02:45:20 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/validation.js.html">lib/validation.js</a></span></td>
       <td data-ice="identifier" class="identifiers">-</td>
-      <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">3/3</span></td>
-      <td style="display: none;" data-ice="size">6643 byte</td>
-      <td style="display: none;" data-ice="lines">162</td>
-      <td style="display: none;" data-ice="updated">2018-02-06 06:39:51 (UTC)</td>
+      <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
+      <td style="display: none;" data-ice="size">6624 byte</td>
+      <td style="display: none;" data-ice="lines">165</td>
+      <td style="display: none;" data-ice="updated">2018-02-04 19:59:39 (UTC)</td>
     </tr>
 </tbody>
 </table>

--- a/docs/typedef/index.html
+++ b/docs/typedef/index.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/docs/variable/index.html
+++ b/docs/variable/index.html
@@ -29,7 +29,11 @@
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~InvalidUsage.html">InvalidUsage</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~RequestCancelled.html">RequestCancelled</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ServiceError.html">ServiceError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/lib/errors.js~ValidationError.html">ValidationError</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-callEndpoint">callEndpoint</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-init">init</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getLowestPricedOffersForASIN">getLowestPricedOffersForASIN</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getMarketplaces">getMarketplaces</a></span></span></li>

--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -3,6 +3,8 @@ const { MWS_ENDPOINTS } = require('./constants');
 const sleep = require('./util/sleep');
 const fs = require('fs');
 
+const errors = require('./errors.js');
+
 /*
  * TODO: split the "init" function out of the "callEndpoint" file, difficulty: callEndpoint
  * depends on having init modify the mws value, which doesn't carry between module pieces in that
@@ -126,7 +128,7 @@ const requestPromise = (requestData, opt = {}) =>
 const callEndpoint = async (name, callOptions = {}, opt = {}) => {
     const endpoint = endpoints[name];
     if (!endpoint) {
-        throw new Error('No endpoint name supplied to callEndpoint');
+        throw new errors.InvalidUsage('No endpoint name supplied to callEndpoint');
     }
 
     const newOptions = endpoint.params ?
@@ -157,32 +159,34 @@ const callEndpoint = async (name, callOptions = {}, opt = {}) => {
         }
         return digResult;
     } catch (err) {
-        if (err.code === 503) {
-            console.warn('***** Error 503 .. throttling?', name);
-            let ms = 2000;
-            if (!endpoint.throttle) {
-                console.warn(`***** throttle information missing for API ${name}`);
-                console.warn('***** ', JSON.stringify(endpoint));
-            } else {
-                // restoreRate = how many you get back in a minute of time. there's an assumption here
-                // that you're spamming a lot of requests if you're hitting throttling, and this
-                // throttle management system is first version, here -- so we're going to throttle it
-                // not to the minimum possible time frame, but to the length of time that it will take
-                // to restore your entire maxInFlight -- assuming you're probably going to hit the max
-                // again as soon as we start letting more requests in.
+        if (err instanceof MWS.ServerError) {
+            if (err.code === 503) {
+                console.warn('***** Error 503 .. throttling?', name);
+                let ms = 2000;
+                if (!endpoint.throttle) {
+                    console.warn(`***** throttle information missing for API ${name}`);
+                    console.warn('***** ', JSON.stringify(endpoint));
+                } else {
+                    // restoreRate = how many you get back in a minute of time. there's an assumption here
+                    // that you're spamming a lot of requests if you're hitting throttling, and this
+                    // throttle management system is first version, here -- so we're going to throttle it
+                    // not to the minimum possible time frame, but to the length of time that it will take
+                    // to restore your entire maxInFlight -- assuming you're probably going to hit the max
+                    // again as soon as we start letting more requests in.
 
-                // ultimately, an upgraded version of this throttling handler would keep track of how
-                // many of every request are in flight, and try to throttle it to the minimum amount
-                // of time that you can go, automatically throttling future calls without having to
-                // even encounter the 503 from the server.
+                    // ultimately, an upgraded version of this throttling handler would keep track of how
+                    // many of every request are in flight, and try to throttle it to the minimum amount
+                    // of time that you can go, automatically throttling future calls without having to
+                    // even encounter the 503 from the server.
 
-                // that day is not today.  it might be tomorrow. maybe next weekend. i don't know. :-)
-                const restoreMaxInFlightMin = (endpoint.throttle.maxInFlight / endpoint.throttle.restoreRate) * (callOptions.IdList ? callOptions.IdList.length : 1);
-                ms = (restoreMaxInFlightMin * 60 * 1000) + 100;
+                    // that day is not today.  it might be tomorrow. maybe next weekend. i don't know. :-)
+                    const restoreMaxInFlightMin = (endpoint.throttle.maxInFlight / endpoint.throttle.restoreRate) * (callOptions.IdList ? callOptions.IdList.length : 1);
+                    ms = (restoreMaxInFlightMin * 60 * 1000) + 100;
+                }
+                console.warn(`***** trying again in ${ms}ms`);
+                await sleep(ms + 100);
+                return callEndpoint(name, callOptions, opt);
             }
-            console.warn(`***** trying again in ${ms}ms`);
-            await sleep(ms + 100);
-            return callEndpoint(name, callOptions, opt);
         }
         throw err;
     }

--- a/lib/dig-response-result.js
+++ b/lib/dig-response-result.js
@@ -1,3 +1,5 @@
+const errors = require('./errors');
+
 /**
  * Return data.${name}Response.${name}Result if available, otherwise return data
  * Convenience method to avoid having to do that in virtually every single response
@@ -8,7 +10,7 @@
  */
 const digResponseResult = (name, data) => {
     if (data.ErrorResponse) {
-        throw new Error(JSON.stringify(data.ErrorResponse));
+        throw new errors.ServiceError(JSON.stringify(data.ErrorResponse));
     }
     if (data[`${name}Response`]) {
         return data[`${name}Response`][`${name}Result`];

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,40 @@
+const extError = require('es6-error');
+
+/**
+ * Thrown when completely Invalid Parameters are given and we have no way of making sense of them
+ *
+ * @class InvalidUsage
+ * @extends {Error}
+ */
+class InvalidUsage extends extError {}
+
+/**
+ * Thrown when an Error response comes from the Service (not a mws-simple.ServerError though)
+ *
+ * @class ServiceError
+ * @extends {extError}
+ */
+class ServiceError extends extError {}
+
+/**
+ * Thrown when a request is cancelled by MWS -- we have no way of knowing automatically if we should retry or not
+ *
+ * @class RequestCancelled
+ * @extends {extError}
+ */
+class RequestCancelled extends extError {}
+
+/**
+ * Thrown when parameters fail validation locally, before being sent to MWS
+ *
+ * @class ValidationError
+ * @extends {extError}
+ */
+class ValidationError extends extError {}
+
+module.exports = {
+    InvalidUsage,
+    RequestCancelled,
+    ServiceError,
+    ValidationError,
+};

--- a/lib/get-matching-product.js
+++ b/lib/get-matching-product.js
@@ -1,5 +1,6 @@
 const { callEndpoint } = require('./callEndpoint');
 const { forceArray, transformKey, transformObjectKeys } = require('./util/transformers');
+const errors = require('./errors');
 
 /**
  * remove a string pattern from a string
@@ -32,7 +33,7 @@ const transformAttributeSetKey = k => transformKey(removeFromString(k)(/^ns2:/))
 const getMatchingProductForId = async (options) => {
     const result = await callEndpoint('GetMatchingProductForId', options);
     if (result.Error) {
-        throw new Error(JSON.stringify(result.Error.Message));
+        throw new errors.ServiceError(result.Error.Message);
     }
     // for a single return, flattenResult will drop this to an object, which is not desireable
     // in this particular case.

--- a/lib/reports.js
+++ b/lib/reports.js
@@ -5,6 +5,8 @@
 const { promisify } = require('util');
 const fs = require('fs');
 
+const errors = require('./errors');
+
 /**
  * Promisified version of fs.writeFile
  * We like to use Promises. writeFile does not come in a Promise variant, currently.
@@ -231,7 +233,7 @@ const requestAndDownloadReport = async (ReportType, file, reportParams = {}) => 
     const reportCheck = await checkReportComplete(reportRequestId);
     if (reportCheck.cancelled) {
         console.warn('******** report request cancelled by server', ReportType);
-        throw new Error('Report cancelled by server');
+        throw new errors.RequestCancelled('Report cancelled by server');
     }
     let ReportId = reportCheck.GeneratedReportId;
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,3 +1,5 @@
+const errors = require('./errors');
+
 // TODO: testing indicates some weirdness in this call. It throws for things that are outside of
 // ranges, but otherwise valid, it throws for things that are not in a list of valid values, but it
 // does not throw for basic type incompatibility, relying on it's caller to throw. Should this throw
@@ -31,7 +33,7 @@ const validateInteger = (type, test, { minValue, maxValue } = { }) => {
     // eslint-disable-next-line eqeqeq
     const valid = test == newTest && (minValue == null || newTest >= minValue) && (maxValue == null || newTest <= maxValue);
     if (!valid) {
-        throw new Error(`Expected type ${type} ${minValue} <= ${test} <= ${maxValue}`);
+        throw new errors.ValidationError(`Expected type ${type} ${minValue} <= ${test} <= ${maxValue}`);
     }
     return valid;
 };
@@ -69,7 +71,7 @@ const isType = (type, test, definition) => {
             valid = true;
     }
     if (valid && definition && definition.values && !definition.values.includes(test)) {
-        throw new Error(`Value ${test} is not in allowed values list: ${definition.values}`);
+        throw new errors.ValidationError(`Value ${test} is not in allowed values list: ${definition.values}`);
     }
     return valid;
 };
@@ -114,7 +116,7 @@ const validateAndTransformParameters = (valid, options) => {
     // check for unknown parameters
     Object.keys(options).forEach((k) => {
         if (!valid[k]) {
-            throw new Error(`Unknown parameter ${k}`);
+            throw new errors.ValidationError(`Unknown parameter ${k}`);
         }
     });
     // check for required, list, and type (inside and outside of list)
@@ -126,27 +128,27 @@ const validateAndTransformParameters = (valid, options) => {
 
         // if required and not found, throw
         if (v.required && !o) {
-            throw new Error(`Required parameter ${k} missing`);
+            throw new errors.ValidationError(`Required parameter ${k} missing`);
         }
         // transform Date objects into ISO strings
         if (v.type === 'xs:dateTime' && o instanceof Date) {
             newOptions[k] = o.toISOString();
         } else if (v.list && o) { // transform lists
             if (!Array.isArray(o)) {
-                throw new Error(`Parameter ${k} expected an array`);
+                throw new errors.ValidationError(`Parameter ${k} expected an array`);
             }
             if (v.listMax && o.length > v.listMax) {
-                throw new Error(`List parameter ${k} can only take up to ${v.listMax} items`);
+                throw new errors.ValidationError(`List parameter ${k} can only take up to ${v.listMax} items`);
             }
             if (!o.every(val => isType(v.type, val, v))) {
-                throw new Error(`List ${k} expects type ${v.type}`);
+                throw new errors.ValidationError(`List ${k} expects type ${v.type}`);
             }
             o.forEach((item, index) => {
                 newOptions[`${v.list}.${index + 1}`] = item;
             });
         } else { // if not already handled, then run it through isType
             if (v && o && !isType(v.type, o, v)) {
-                throw new Error(`Expected type ${v.type} for ${k}`);
+                throw new errors.ValidationError(`Expected type ${v.type} for ${k}`);
             }
             if (k && o) {
                 newOptions[k] = o;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -792,6 +792,11 @@
                 "is-arrayish": "0.2.1"
             }
         },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2622,7 +2627,7 @@
             "dev": true
         },
         "mws-simple": {
-            "version": "github:ericblade/mws-simple#58beffdab1852b2bf1968ad3e671b177f7658839",
+            "version": "github:ericblade/mws-simple#d0d48145dd83d87e5ac2eca98bdc20f5a757c6fb",
             "requires": {
                 "csv-parse": "2.0.2",
                 "query-string": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --timeout=5000",
+    "test": "./node_modules/.bin/mocha --timeout=7000",
     "coverage": "./node_modules/.bin/nyc --reporter=lcov ./node_modules/.bin/mocha --timeout=5000",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "coverage-codebeat": "./send-coverage",
@@ -28,7 +28,8 @@
   "author": "Eric Blade <blade.eric@gmail.com>",
   "license": "Apache",
   "dependencies": {
-    "mws-simple": "github:ericblade/mws-simple#2.2.0"
+    "es6-error": "^4.1.1",
+    "mws-simple": "github:ericblade/mws-simple#2.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -28,6 +28,8 @@ const errorData = require('./errorData.json');
 
 const transformers = require('../lib/util/transformers');
 
+const errors = require('../lib/errors');
+
 describe('Sanity', () => {
     it('true is true', (done) => {
         expect(true).to.equal(true);
@@ -88,8 +90,8 @@ describe('Misc Utils', () => {
         expect(result).to.have.keys('ListParticipations', 'ListMarketplaces');
         done();
     });
-    it('digResponseResult() throws on error', (done) => {
-        expect(() => digResponseResult('ListMarketplaceParticipations', errorData)).to.throw();
+    it('digResponseResult() throws ServiceError on error message (simulated from server)', (done) => {
+        expect(() => digResponseResult('ListMarketplaceParticipations', errorData)).to.throw(errors.ServiceError);
         done();
     });
 });
@@ -198,39 +200,39 @@ describe('isType', () => {
         expect(isType('xs:int', 1000)).to.be.true;
         expect(isType('xs:int', -1)).to.be.true;
         expect(isType('xs:int', -1000)).to.be.true;
-        expect(() => isType('xs:int', 0.1234)).to.throw();
+        expect(() => isType('xs:int', 0.1234)).to.throw(errors.ValidationError);
         expect(isType('xs:int', '1234')).to.be.true;
-        expect(() => isType('xs:int', 'coffee')).to.throw();
-        expect(() => isType('xs:int', { test: 1 })).to.throw();
+        expect(() => isType('xs:int', 'coffee')).to.throw(errors.ValidationError);
+        expect(() => isType('xs:int', { test: 1 })).to.throw(errors.ValidationError);
         done();
     });
     it('xs:positiveInteger', (done) => {
-        expect(() => isType('xs:positiveInteger', -100)).to.throw();
-        expect(() => isType('xs:positiveInteger', 0)).to.throw();
+        expect(() => isType('xs:positiveInteger', -100)).to.throw(errors.ValidationError);
+        expect(() => isType('xs:positiveInteger', 0)).to.throw(errors.ValidationError);
         expect(isType('xs:positiveInteger', 100)).to.be.true;
-        expect(() => isType('xs:positiveInteger', 'string')).to.throw();
-        expect(() => isType('xs:positiveInteger', { test: true })).to.throw();
+        expect(() => isType('xs:positiveInteger', 'string')).to.throw(errors.ValidationError);
+        expect(() => isType('xs:positiveInteger', { test: true })).to.throw(errors.ValidationError);
         done();
     });
     it('xs:nonNegativeInteger', (done) => {
-        expect(() => isType('xs:nonNegativeInteger', -100)).to.throw();
+        expect(() => isType('xs:nonNegativeInteger', -100)).to.throw(errors.ValidationError);
         expect(isType('xs:nonNegativeInteger', 0)).to.be.true;
         expect(isType('xs:nonNegativeInteger', 100)).to.be.true;
-        expect(() => isType('xs:nonNegativeInteger', 'string')).to.throw();
-        expect(() => isType('xs:nonNegativeInteger', { test: true })).to.throw();
+        expect(() => isType('xs:nonNegativeInteger', 'string')).to.throw(errors.ValidationError);
+        expect(() => isType('xs:nonNegativeInteger', { test: true })).to.throw(errors.ValidationError);
         done();
     });
     it('integer ranging', (done) => {
         const range = { minValue: 10, maxValue: 100 };
-        expect(() => isType('xs:int', 1, range)).to.throw();
-        expect(() => isType('xs:positiveInteger', 1, range)).to.throw();
-        expect(() => isType('xs:nonNegativeInteger', 1, range)).to.throw();
+        expect(() => isType('xs:int', 1, range)).to.throw(errors.ValidationError);
+        expect(() => isType('xs:positiveInteger', 1, range)).to.throw(errors.ValidationError);
+        expect(() => isType('xs:nonNegativeInteger', 1, range)).to.throw(errors.ValidationError);
         expect(isType('xs:int', 50, range)).to.be.true;
         expect(isType('xs:positiveInteger', 50, range)).to.be.true;
         expect(isType('xs:nonNegativeInteger', 50, range)).to.be.true;
-        expect(() => isType('xs:int', 1000, range)).to.throw();
-        expect(() => isType('xs:positiveInteger', 1000, range)).to.throw();
-        expect(() => isType('xs:nonNegativeInteger', 1000, range)).to.throw();
+        expect(() => isType('xs:int', 1000, range)).to.throw(errors.ValidationError);
+        expect(() => isType('xs:positiveInteger', 1000, range)).to.throw(errors.ValidationError);
+        expect(() => isType('xs:nonNegativeInteger', 1000, range)).to.throw(errors.ValidationError);
         done();
     });
     it('xs:string accepts regular strings', (done) => {
@@ -258,19 +260,19 @@ describe('isType', () => {
         done();
     });
     it('xs:dateTime fails non-ISO strings', (done) => {
-        expect(() => isType('xs:dateTime', 'string')).to.throw(); // Date constructor throws
+        expect(() => isType('xs:dateTime', 'string')).to.throw(RangeError); // Date constructor throws
         expect(isType('xs:dateTime', 12345)).to.be.false;
-        expect(() => isType('xs:dateTime', { test: true })).to.throw(); // Date constructor throws
+        expect(() => isType('xs:dateTime', { test: true })).to.throw(RangeError); // Date constructor throws
         done();
     });
     it('allowed values works', (done) => {
         const allowed = { values: ['test1', 'test2', 2, 3] };
         expect(isType('xs:string', 'test1', allowed)).to.be.true;
         expect(isType('xs:string', 'test2', allowed)).to.be.true;
-        expect(() => isType('xs:string', 'test3', allowed)).to.throw();
+        expect(() => isType('xs:string', 'test3', allowed)).to.throw(errors.ValidationError);
         expect(isType('xs:positiveInteger', 2, allowed)).to.be.true;
         expect(isType('xs:nonNegativeInteger', 3, allowed)).to.be.true;
-        expect(() => isType('xs:positiveInteger', 100, allowed)).to.throw();
+        expect(() => isType('xs:positiveInteger', 100, allowed)).to.throw(errors.ValidationError);
         done();
     });
 });
@@ -304,7 +306,7 @@ describe('validateAndTransformParameters', () => {
             done();
         });
         it('required parameter not present throws', (done) => {
-            expect(() => validateAndTransformParameters(req, { NotReqTest: 'test' })).to.throw();
+            expect(() => validateAndTransformParameters(req, { NotReqTest: 'test' })).to.throw(errors.ValidationError);
             done();
         });
     });
@@ -318,19 +320,19 @@ describe('validateAndTransformParameters', () => {
             },
         };
         it('throws on non-Arrays', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: 'oops' })).to.throw();
+            expect(() => validateAndTransformParameters(listTest, { ListTest: 'oops' })).to.throw(errors.ValidationError);
             done();
         });
         it('throws on incorrect list data types', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: [123] })).to.throw();
+            expect(() => validateAndTransformParameters(listTest, { ListTest: [123] })).to.throw(errors.ValidationError);
             done();
         });
         it('throws on partial incorrect list data types', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: ['a', 1] })).to.throw();
+            expect(() => validateAndTransformParameters(listTest, { ListTest: ['a', 1] })).to.throw(errors.ValidationError);
             done();
         });
         it('throws on exceeding listMax items', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: ['1', '2', '3'] })).to.throw();
+            expect(() => validateAndTransformParameters(listTest, { ListTest: ['1', '2', '3'] })).to.throw(errors.ValidationError);
             done();
         });
         it('outputs correct list parameters (ListTest[x] => Test.List.x+1)', (done) => {
@@ -563,12 +565,11 @@ describe('mws-advanced sanity', () => {
             expect(x[0]).to.include.all.keys('$', 'Products');
             return true;
         });
-        // TODO: be more specific about which Error is being rejected back here, so when there's a code error in callEndpoint, it doesn't phantom pass
         it('callEndpoint throws on unknown endpoint', () => {
-            return expect(mws.callEndpoint('/test/endpoint', {})).to.be.rejectedWith(Error);
+            return expect(mws.callEndpoint('/test/endpoint', {})).to.be.rejectedWith(errors.InvalidUsage);
         });
         it('callEndpoint throws on garbage parameters', () => {
-            return expect(mws.callEndpoint('GetOrder', { junkTest: true })).to.be.rejectedWith(Error);
+            return expect(mws.callEndpoint('GetOrder', { junkTest: true })).to.be.rejectedWith(errors.ValidationError);
         });
     });
 });
@@ -728,7 +729,6 @@ describe('API', function runAPITests() {
                 expect(result[0].id).to.equal('020357122682');
                 return result;
             });
-            // TODO: get more specific about what type of Error we expect - code errors cause success
             it('getMatchingProductForId with invalid UPC', function testGetMatchingProductForId4() {
                 const params = {
                     MarketplaceId: 'ATVPDKIKX0DER',
@@ -736,18 +736,16 @@ describe('API', function runAPITests() {
                     IdList: ['012345678900'],
                 };
                 // Error: {"Type":"Sender","Code":"InvalidParameterValue","Message":"Invalid UPC identifier 000000000000 for marketplace ATVPDKIKX0DER"}
-                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(Error);
+                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(errors.ServiceError);
             });
-            // TODO: get more specific about what type of Error
             it('getMatchingProductForId with ASIN that has been deleted', async function testGetMatchingProductForId5() {
                 const params = {
                     MarketplaceId: 'ATVPDKIKX0DER',
                     IdType: 'ASIN',
                     IdList: ['B01FZRFN2C'],
                 };
-                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(Error);
+                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(errors.ServiceError);
             });
-            // TODO: be more specific about what type of Error
             // oddly, the Amazon API throws Error 400 from the server if you give it duplicate items, instead of ignoring dupes or throwing individual errors, or returning multiple copies.
             it('getMatchingProductForId with duplicate ASINs in list', async function testGetMatchingProductForId6() {
                 const params = {
@@ -755,7 +753,7 @@ describe('API', function runAPITests() {
                     IdType: 'ASIN',
                     IdList: ['B005NK7VTU', 'B00OB8EYZE', 'B005NK7VTU', 'B00OB8EYZE'],
                 };
-                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(Error);
+                return expect(mws.getMatchingProductForId(params)).to.be.rejectedWith(mws.ServiceError);
             });
             it('getMatchingProductForId with partial error (1 asin that works, 1 that doesnt)', async function testGetMatchingProductForId7() {
                 const params = {


### PR DESCRIPTION
- use es6-error for extending custom Error classes
- add lib/errors.js
- contains InvalidUsage, ServiceError, RequestCancelled, ValidationError
- throw InvalidUsage when calling callEndpoint with nonsensical data
- enhance handling of throttling using ServerError from mws-simple 2.2.1
- throw ServiceError when MWS service returns an error code (not from the
  web server, but from the MWS service) (digResponseResult)
- throw ServiceError when receiving an error on getMatchingProductForId
  (this function does not use digResponseResult)
- throw RequestCancelled when determining that a Report is cancelled at
  the service side, during requestAndDownloadReport
- throw ValidationError for all the various types of errors that can
  be thrown directly from validation.js.  Note that Date conversions that
  fail will throw RangeError instead, as those come from the Date
  constructor, rather than code in validation.js
- update mws-simple=2.2.1
- update all tests that use throw() or rejectedWith() to expect the correct
  Error subclasses