### PR TITLE
fix for potential cache stampede

### DIFF
--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -178,28 +178,28 @@ const callEndpoint = async (
     };
 
     const cacheKey = opt.useCache ? JSON.stringify(params) : undefined;
-    if (opt.useCache) {
-        if (callCache[cacheKey]) {
-            return callCache[cacheKey];
-        }
+    if (opt.useCache && callCache[cacheKey]) {
+        return callCache[cacheKey];
     }
 
     let throttleRetries = 0;
     try {
-        const result = await requestPromise(params, { noFlatten: opt.noFlatten });
-        if (opt.saveRaw) {
-            fs.writeFileSync(opt.saveRaw, JSON.stringify(result));
-        }
-        if (opt.returnRaw) {
-            callCache[cacheKey] = result;
-            return result;
-        }
-        const digResult = digResponseResult(name, result);
-        if (opt.saveParsed) {
-            fs.writeFileSync(opt.saveParsed, JSON.stringify(digResult));
-        }
-        callCache[cacheKey] = digResult;
-        return digResult;
+        const resultPromise = requestPromise(params, { noFlatten: opt.noFlatten }).then((result) => {
+            if (opt.saveRaw) {
+                fs.writeFileSync(opt.saveRaw, JSON.stringify(result));
+            }
+            if (opt.returnRaw) {
+                return result;
+            }
+            const digResult = digResponseResult(name, result);
+            callCache[cacheKey] = digResult;
+            if (opt.saveParsed) {
+                fs.writeFileSync(opt.saveParsed, JSON.stringify(digResult));
+            }
+            return digResult;
+        });
+        callCache[cacheKey] = resultPromise;
+        return resultPromise;
     } catch (err) {
         if (err instanceof MWS.ServerError) {
             if (err.code === 503 && opt.maxThrottleRetries > 0 && throttleRetries <= opt.maxThrottleRetries) {


### PR DESCRIPTION
- cache API call promises, and return those promises, so that even if
  multiple identical requests are in flight simultaneously for a response,
  only the first one will actually go to the API, and all the rest will
  be resolved automatically when the first request is resolved.
- if the cached data needs further processing (ie digResponseResult) before
  it can be returned to the internal mws-advanced API, then overwrite the
  promise in the cache with the actual data returned, once it is available.
- once the original promise is resolved, it will also return the
  digResponseResult or the returnRaw result, whichever is asked.
- hmm. we may need to add { ...opt } to the cache key string.. need to test