### PR TITLE
fix #42, strings turning into objects in getMatchingProductForId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.json
 !.esdoc.json
 !test/*.json
+!test/data/*
 !npm-shrinkwrap.json
 test/keys.json
 node_modules

--- a/lib/get-matching-product.js
+++ b/lib/get-matching-product.js
@@ -1,23 +1,6 @@
 const { callEndpoint } = require('./callEndpoint');
-const { forceArray, transformKey, transformObjectKeys } = require('./util/transformers');
+const { forceArray, transformObjectKeys, transformAttributeSetKey } = require('./util/transformers');
 const errors = require('./errors');
-
-/**
- * remove a string pattern from a string
- *
- * @param {string} str string to remove pattern from
- * @param {string|regex} pattern pattern to remove
- * @return {string} string with the pattern removed
- */
-const removeFromString = str => pattern => str.replace(pattern, '');
-
-/**
- * Special key transformer for transformObjectKeys to strip "ns2:" from the beginning of keys,
- * such as 'ns2:ItemAttributes'
- *
- * @param {any} k
- */
-const transformAttributeSetKey = k => transformKey(removeFromString(k)(/^ns2:/));
 
 /**
  * Returns a list of products and their attributes, based on a list of ASIN, GCID, SellerSKU, UPC,

--- a/lib/util/transformers.js
+++ b/lib/util/transformers.js
@@ -83,6 +83,42 @@ const objToValueSub = obj => ({
 
 const transformKey = k => (isUpperCase(k) ? k : camelize(k));
 
+/**
+ * remove a string pattern from a string
+ *
+ * @param {string} str string to remove pattern from
+ * @param {string|regex} pattern pattern to remove
+ * @return {string} string with the pattern removed
+ */
+const removeFromString = (str, pattern) => str.replace(pattern, '');
+
+/**
+ * Special key transformer for transformObjectKeys to strip "ns2:" from the beginning of keys,
+ * such as 'ns2:ItemAttributes'
+ *
+ * @param {any} k
+ */
+const transformAttributeSetKey = k => transformKey(removeFromString(k, /^ns2:/));
+
+/**
+ * Transforms an object, and it's keys. Use keyTransformer as a special key transformer function.
+ *
+ * This is a rather complex function, which takes unintuitive JSON from XML conversion, and attempts
+ * to organize it in a more understandable fashion.  It will convert internal objects such as:
+ * { "_": "4.20", "$": { "Units": "inches" } }
+ * to
+ * { "inches": "4.20" }
+ *
+ * With the application of keyTransformer, you can also convert something like
+ * { "ns2:ManufacturerMinimumAge": { "_": "36", "$": { "Units": "months" } } }
+ * to a much more readable:
+ * { "manufacturerMinimumAge: { "months": "36" } },
+ *
+ * @param {any} obj
+ * @param {any} [keyTransformer=transformKey]
+ * @returns transformed object
+ */
+
 /* eslint-disable no-param-reassign */
 const transformObjectKeys = (obj, keyTransformer = transformKey) => {
     if (typeof obj.$ === 'object') {
@@ -93,7 +129,9 @@ const transformObjectKeys = (obj, keyTransformer = transformKey) => {
         }
     }
     if (Array.isArray(obj)) {
-        return obj.map((x => transformObjectKeys(x, keyTransformer)));
+        // map objects in array through this function, otherwise simply return the item
+        const ret = obj.map((x => (typeof x === 'object' ? transformObjectKeys(x, keyTransformer) : x)));
+        return ret;
     }
     const ret = Object.keys(obj).reduce((r, key) => {
         const destKey = keyTransformer(key);
@@ -112,6 +150,7 @@ module.exports = {
     forceArray, // not public, exported for other modules inside this lib
     transformObjectKeys,
     transformKey, // not public, but exported for other modules inside this lib to use it
+    transformAttributeSetKey,
 };
 
 if (process.env.NODE_ENV === 'testing') {
@@ -120,6 +159,7 @@ if (process.env.NODE_ENV === 'testing') {
         camelize,
         isUpperCase,
         objToValueSub,
+        removeFromString,
         subObjUpLevel,
     };
 }

--- a/samples/getMatchingProductForId.js
+++ b/samples/getMatchingProductForId.js
@@ -5,10 +5,16 @@ mws.init(keys);
 
 async function main() {
     try {
+        // const results = await mws.getMatchingProductForId({
+        //     MarketplaceId: 'ATVPDKIKX0DER',
+        //     IdType: 'ASIN',
+        //     IdList: ['B005NK7VTU', 'B01FZRFN2C'],
+        // });
+
         const results = await mws.getMatchingProductForId({
             MarketplaceId: 'ATVPDKIKX0DER',
-            IdType: 'ASIN',
-            IdList: ['B005NK7VTU', 'B01FZRFN2C'],
+            IdType: 'UPC',
+            IdList: ['746775298494'],
         });
 
         console.warn(JSON.stringify(results, null, 4));

--- a/test/data/transformObjectKeys-1.json
+++ b/test/data/transformObjectKeys-1.json
@@ -1,0 +1,22 @@
+{
+    "A2EUQ1WTGCTBG2": {
+        "MarketplaceId": "A2EUQ1WTGCTBG2",
+        "DefaultCountryCode": "CA",
+        "DomainName": "www.amazon.ca",
+        "Name": "Amazon.ca",
+        "DefaultCurrencyCode": "CAD",
+        "DefaultLanguageCode": "en_CA",
+        "SellerId": "SELLERID",
+        "HasSellerSuspendedListings": "No"
+    },
+    "ATVPDKIKX0DER": {
+        "MarketplaceId": "ATVPDKIKX0DER",
+        "DefaultCountryCode": "US",
+        "DomainName": "www.amazon.com",
+        "Name": "Amazon.com",
+        "DefaultCurrencyCode": "USD",
+        "DefaultLanguageCode": "en_US",
+        "SellerId": "SELLERID",
+        "HasSellerSuspendedListings": "No"
+    }
+}

--- a/test/data/transformObjectKeys-2.json
+++ b/test/data/transformObjectKeys-2.json
@@ -1,0 +1,1018 @@
+[
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IDD9TU8"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:Color": "Red",
+                "ns2:Department": "boys",
+                "ns2:Edition": "2014 HW City Speed Team",
+                "ns2:ItemDimensions": {
+                    "ns2:Height": {
+                        "_": "1.20",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.80",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.20",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.10",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:MaterialType": [
+                    "metal",
+                    "plastic"
+                ],
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.199999998776",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.799999993064",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.199999995716000393700787",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.10000000000000002",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "bff93",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/514QItLKewL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "68",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "Hot Wheels 2014 HW City Porsche Panamera 40/250, Red"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "638642"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "8170"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "213967"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IH00CN0"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:ItemDimensions": {
+                    "ns2:Height": {
+                        "_": "4.00",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "2.00",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "6.00",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:ListPrice": {
+                    "ns2:Amount": "99.00",
+                    "ns2:CurrencyCode": "USD"
+                },
+                "ns2:Manufacturer": "Mattel",
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.299999998674",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.199999993676000393700787",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "3.699999996226000393700787",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.07",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "3339913",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51wZ0b3iiyL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "50",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "2014 HOT WHEELS 92 BMW M3 by Hot Wheels"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "907560"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "13187"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IGZUOVG"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/414aQbB-jzL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "36",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "2014 HOT WHEELS \" '73 FORD FALCON XB \" K-DAY EVENT **NEW** 1/64 F CASE"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "1806958"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "34604"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "540674"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00PR3KZWS"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:ItemDimensions": {
+                    "ns2:Height": {
+                        "_": "1.20",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "3.40",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "1.50",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.14",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:ManufacturerMaximumAge": {
+                    "_": "5.00",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.199999998776",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "3.399999996532",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "1.49999999847",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.1399999998825973380462262",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "4659888",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51UvlC8gK%2BL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "47",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "2014 Hot Wheels Hw City - 1999 Ford Mustang (Silver)"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "762803"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "10404"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "251549"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IT5R23G"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:ItemDimensions": {
+                    "ns2:Weight": {
+                        "_": "0.2204622620",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "MATTEL",
+                "ns2:Manufacturer": "MATTEL",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.99999999796",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.899999992962",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.299999995613999606299213",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.20000000000000004",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "43193-7434",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "MATTEL",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51zfDEx6YjL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "MATTEL",
+                "ns2:Title": "Hot Wheels 2014 HW City Porsche 993 GT2 27/250, Red"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "471657"
+                },
+                {
+                    "ProductCategoryId": "251913011",
+                    "Rank": "3482"
+                },
+                {
+                    "ProductCategoryId": "3244725011",
+                    "Rank": "4775"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00NXLNHXK"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:ItemDimensions": {
+                    "ns2:Height": {
+                        "_": "1.40",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.50",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.20",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.02",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "156",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.3999999985719998425196852",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.49999999337",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.199999995716000393700787",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.022046001186074866",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "3277216",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51bme3FBSCL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "56",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "2014 Hot Wheels Hw City 100/250 - 2015 Ford Mustang GT"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "1189561"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "19079"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IQY12WM"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:Color": "Red",
+                "ns2:Department": "Boys",
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Hot Wheels",
+                "ns2:Manufacturer": "Hot Wheels",
+                "ns2:ManufacturerMaximumAge": {
+                    "_": "36.00",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:MaterialType": [
+                    "Metal",
+                    "Plastic"
+                ],
+                "ns2:Model": "L2593",
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "0.099999999898",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "4.199999995716000393700787",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "1.299999998674",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.10000000000000002",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "BFC60",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Hot Wheels",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51y-oArKJvL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "56",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Hot Wheels",
+                "ns2:Title": "2014 Hot Wheels HW CITY HW Pursuit 45/250 (Red/White Version)"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "1163968"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "18525"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "368260"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IH057XA"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:ItemDimensions": {
+                    "ns2:Height": {
+                        "_": "2.10",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "7.50",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.50",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.20",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.249999998725",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "6.49999999337",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.249999995665",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.3999999996645637820462262",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "3276255",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51tDR8%2Bgo8L._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "48",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "2014 \"F\" Case K-mart Exclusive Paint Scheme Card '64 Lincoln Continental 208/250"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "1187629"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "19037"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00OMCM8W0"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Mattel",
+                "ns2:Manufacturer": "Mattel",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "2.0999999978580001968503935",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "7.49999999235",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "4.49999999541",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.20000000000000004",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Mattel",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/51xgv2FWm-L._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Mattel",
+                "ns2:Title": "Matchbox 2014 MBX Heroic Rescue Ford Police Interceptor Taurus Green Marshall"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "945955"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "13919"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "305278"
+                }
+            ]
+        }
+    },
+    {
+        "Identifiers": {
+            "MarketplaceASIN": {
+                "MarketplaceId": "ATVPDKIKX0DER",
+                "ASIN": "B00IGZXG4I"
+            }
+        },
+        "AttributeSets": {
+            "ns2:ItemAttributes": {
+                "$": {
+                    "xml:lang": "en-US"
+                },
+                "ns2:Binding": "Toy",
+                "ns2:Brand": "Hot Wheels",
+                "ns2:IsAdultProduct": "false",
+                "ns2:Label": "Hot Wheels",
+                "ns2:Manufacturer": "Hot Wheels",
+                "ns2:ManufacturerMinimumAge": {
+                    "_": "36.00",
+                    "$": {
+                        "Units": "months"
+                    }
+                },
+                "ns2:PackageDimensions": {
+                    "ns2:Height": {
+                        "_": "1.299999998674",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Length": {
+                        "_": "3.599999996328",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "1.599999998368",
+                        "$": {
+                            "Units": "inches"
+                        }
+                    },
+                    "ns2:Weight": {
+                        "_": "0.07",
+                        "$": {
+                            "Units": "pounds"
+                        }
+                    }
+                },
+                "ns2:PackageQuantity": "1",
+                "ns2:PartNumber": "5049339",
+                "ns2:ProductGroup": "Toy",
+                "ns2:ProductTypeName": "TOYS_AND_GAMES",
+                "ns2:Publisher": "Hot Wheels",
+                "ns2:SmallImage": {
+                    "ns2:URL": "http://ecx.images-amazon.com/images/I/511xFkRJZcL._SL75_.jpg",
+                    "ns2:Height": {
+                        "_": "75",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    },
+                    "ns2:Width": {
+                        "_": "51",
+                        "$": {
+                            "Units": "pixels"
+                        }
+                    }
+                },
+                "ns2:Studio": "Hot Wheels",
+                "ns2:Title": "Hot Wheels TOYOTA 2000 GT #192~ New YELLOW~ HW Workshop"
+            }
+        },
+        "Relationships": "",
+        "SalesRankings": {
+            "SalesRank": [
+                {
+                    "ProductCategoryId": "toy_display_on_website",
+                    "Rank": "411440"
+                },
+                {
+                    "ProductCategoryId": "2519979011",
+                    "Rank": "4717"
+                },
+                {
+                    "ProductCategoryId": "251910011",
+                    "Rank": "142218"
+                }
+            ]
+        }
+    }
+]

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -183,7 +183,42 @@ describe('transformers', () => {
             return true;
         });
     });
+    describe('removeFromString', () => {
+        it('returns a string minus a substring', () => {
+            expect(transformers.removeFromString('testString', 'String')).to.equal('test');
+        });
+        it('returns a string minus a regex pattern', () => {
+            expect(transformers.removeFromString('testString', /^test/)).to.equal('String');
+        });
+    });
+    describe('transformAttributeSetKey', () => {
+        it('extends transformKey to remove "ns2:" from beginning of key, ns2:ItemAttributes=>itemAttributes', () => {
+            expect(transformers.transformAttributeSetKey('ns2:ItemAttributes')).to.equal('itemAttributes');
+        });
+    });
     describe('transformObjectKeys', () => {
+        it('simple test with getMarketplaces data', () => {
+            const testData = require('./data/transformObjectKeys-1.json');
+            /* eslint-disable dot-notation */
+            const res = transformers.transformObjectKeys(testData)['ATVPDKIKX0DER'];
+            const comp = testData['ATVPDKIKX0DER'];
+            /* eslint-enable dot-notation */
+            expect(comp.MarketplaceId).to.equal(res.marketplaceId);
+            expect(comp.DefaultCountryCode).to.equal(res.defaultCountryCode);
+            expect(comp.DomainName).to.equal(res.domainName);
+            expect(comp.Name).to.equal(res.name);
+            expect(comp.DefaultCurrencyCode).to.equal(res.defaultCurrencyCode);
+            expect(comp.DefaultLanguageCode).to.equal(res.defaultLanguageCode);
+            expect(comp.SellerId).to.equal(res.sellerId);
+            expect(comp.HasSellerSuspendedListings).to.equal(res.hasSellerSuspendedListings);
+        });
+        it('extended test with getMatchingProductForId attribute data, using transformAttributeSetKey, test ns2:MaterialType => materialType', () => {
+            const testData = require('./data/transformObjectKeys-2.json');
+            const res = transformers.transformObjectKeys(testData, transformers.transformAttributeSetKey);
+            testData.forEach((x, i) => {
+                expect(x.AttributeSets['ns2:ItemAttributes']['ns2:MaterialType']).to.deep.equal(res[i].attributeSets.itemAttributes.materialType);
+            });
+        });
         // TODO: write detailed tests for transformObjectKeys.
         // TODO: should grab actual data from the base API and compare it.
     });


### PR DESCRIPTION
- move removeFromString and transformAttributeSetKey from
  getMatchingProductForId to transformers, where they are more appropriate
- add tests for removeFromString, transformAttributeSetKey
- add partial tests for transformObjectKeys, specifically to test
  basic usage, and more advanced usage wrt the broken keys returned
  as referenced in #42
- do not recurse transformObjectKeys on Array items that are not actually
  objects.  In hindsight, this might possibly break arrays of arrays of
  objects. Ugh.  More testing is required.  This function is quite
  complex with regards to recursion.