### PR TITLE
BREAKING CHANGE ALERT - listOrderItems, big output format change

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,50 +28,53 @@
 -   [parseMarketplaceData][24]
 -   [listOrderItems][25]
 -   [listOrderItems][26]
--   [forceArray][27]
--   [removeFromString][28]
--   [transformAttributeSetKey][29]
--   [transformObjectKeys][30]
--   [listOrders][31]
--   [listFinancialEvents][32]
--   [listInventorySupply][33]
--   [getMatchingProductForId][34]
--   [getIdFromProductList][35]
--   [getIdFromProductList][36]
--   [parseMatchingProduct][37]
--   [getLowestPricedOffersForASIN][38]
--   [getLowestPricedOffersForSKU][39]
--   [reformatOfferCount][40]
--   [reformatOffer][41]
--   [reformatOffer][42]
--   [reformatOffer][43]
+-   [transformIntsAndBools][27]
+-   [transformIntsAndBools][28]
+-   [transformIntsAndBools][29]
+-   [listOrders][30]
+-   [listFinancialEvents][31]
+-   [forceArray][32]
+-   [removeFromString][33]
+-   [transformAttributeSetKey][34]
+-   [transformObjectKeys][35]
+-   [listInventorySupply][36]
+-   [getMatchingProductForId][37]
+-   [getIdFromProductList][38]
+-   [getIdFromProductList][39]
+-   [parseMatchingProduct][40]
+-   [getLowestPricedOffersForASIN][41]
+-   [getLowestPricedOffersForSKU][42]
+-   [reformatOfferCount][43]
 -   [reformatOffer][44]
 -   [reformatOffer][45]
--   [reformatLowestPrice][46]
--   [reformatBuyBoxPrice][47]
--   [reformatSummary][48]
--   [parseLowestPricedOffers][49]
--   [getProductCategoriesForAsins][50]
--   [getProductCategoriesForAsins][51]
--   [getProductCategoriesForAsins][52]
+-   [reformatOffer][46]
+-   [reformatOffer][47]
+-   [reformatOffer][48]
+-   [reformatLowestPrice][49]
+-   [reformatBuyBoxPrice][50]
+-   [reformatSummary][51]
+-   [parseLowestPricedOffers][52]
 -   [getProductCategoriesForAsins][53]
--   [getProductCategoriesForSkus][54]
--   [getMyFeesEstimate][55]
--   [getMyFeesEstimate][56]
--   [getMyFeesEstimate][57]
+-   [getProductCategoriesForAsins][54]
+-   [getProductCategoriesForAsins][55]
+-   [getProductCategoriesForAsins][56]
+-   [getProductCategoriesForSkus][57]
 -   [getMyFeesEstimate][58]
 -   [getMyFeesEstimate][59]
--   [listMatchingProducts][60]
--   [writeFile][61]
--   [requestReport][62]
--   [requestReport][63]
--   [getReportRequestList][64]
--   [getReportRequestList][65]
--   [getReport][66]
--   [getReportList][67]
--   [getReportListByNextToken][68]
--   [getReportListAll][69]
--   [requestAndDownloadReport][70]
+-   [getMyFeesEstimate][60]
+-   [getMyFeesEstimate][61]
+-   [getMyFeesEstimate][62]
+-   [listMatchingProducts][63]
+-   [writeFile][64]
+-   [requestReport][65]
+-   [requestReport][66]
+-   [getReportRequestList][67]
+-   [getReportRequestList][68]
+-   [getReport][69]
+-   [getReportList][70]
+-   [getReportListByNextToken][71]
+-   [getReportListAll][72]
+-   [requestAndDownloadReport][73]
 
 ## mws-advanced
 
@@ -90,9 +93,9 @@ to this instance of MWSAdvanced.
 
 **Parameters**
 
--   `rest` **[object][71]** passed on to @see [#init][6]
+-   `rest` **[object][74]** passed on to @see [#init][6]
 
-Returns **[MWSAdvanced][72]** new instance of MWSAdvanced
+Returns **[MWSAdvanced][75]** new instance of MWSAdvanced
 
 ## mws
 
@@ -106,15 +109,15 @@ the environment variables MWS_ACESS_KEY, MWS_SECRET_ACCESS_KEY, and MWS_MERCHANT
 
 **Parameters**
 
--   `config` **[object][71]** Contains your MWS Access Keys/Tokens and options to configure the API (optional, default `{}`)
-    -   `config.region` **[string][73]** One of the Amazon regions as specified in [https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html][74] (optional, default `'NA'`)
-    -   `config.accessKeyId` **[string][73]** Your MWS Access Key (optional, default `process.env.MWS_ACCESS_KEY`)
-    -   `config.secretAccessKey` **[string][73]** Your MWS Secret Access Key (optional, default `process.env.MWS_SECRET_ACCESS_KEY`)
-    -   `config.merchantId` **[string][73]** Your MWS Merchant ID (optional, default `process.env.MWS_MERCHANT_ID`)
-    -   `config.authToken` **[string][73]?** If making a call for a third party account, the Auth Token provided
+-   `config` **[object][74]** Contains your MWS Access Keys/Tokens and options to configure the API (optional, default `{}`)
+    -   `config.region` **[string][76]** One of the Amazon regions as specified in [https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html][77] (optional, default `'NA'`)
+    -   `config.accessKeyId` **[string][76]** Your MWS Access Key (optional, default `process.env.MWS_ACCESS_KEY`)
+    -   `config.secretAccessKey` **[string][76]** Your MWS Secret Access Key (optional, default `process.env.MWS_SECRET_ACCESS_KEY`)
+    -   `config.merchantId` **[string][76]** Your MWS Merchant ID (optional, default `process.env.MWS_MERCHANT_ID`)
+    -   `config.authToken` **[string][76]?** If making a call for a third party account, the Auth Token provided
                                   for the third party account
-    -   `config.host` **[string][73]** Set MWS host server name, see [https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html][74] (optional, default `'mws.amazonservices.com'`)
-    -   `config.port` **[number][75]** Set MWS host port (optional, default `443`)
+    -   `config.host` **[string][76]** Set MWS host server name, see [https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html][77] (optional, default `'mws.amazonservices.com'`)
+    -   `config.port` **[number][78]** Set MWS host port (optional, default `443`)
 
 **Examples**
 
@@ -138,14 +141,14 @@ transformed and validated according to the rules defined in lib/endpoints
 
 **Parameters**
 
--   `name` **[string][73]** name of MWS API function to call
--   `callOptions` **[object][71]?** named hash object of the parameters to pass to the API (optional, default `{}`)
-    -   `callOptions.feedContent` **[string][73]?** if calling a function that submits a feed, supply the feed data here
--   `opt` **[object][71]?** options for callEndpoint (optional, default `{maxThrottleRetries:2}`)
-    -   `opt.noFlatten` **[boolean][76]?** do not flatten results
-    -   `opt.returnRaw` **[boolean][76]?** return only the raw data (may or may not be flattened)
-    -   `opt.saveRaw` **[string][73]?** filename to save raw data to (may or may not be flattened)
-    -   `opt.saveParsed` **[string][73]?** filename to save final parsed data to (not compatible with returnRaw, since parsing won't happen)
+-   `name` **[string][76]** name of MWS API function to call
+-   `callOptions` **[object][74]?** named hash object of the parameters to pass to the API (optional, default `{}`)
+    -   `callOptions.feedContent` **[string][76]?** if calling a function that submits a feed, supply the feed data here
+-   `opt` **[object][74]?** options for callEndpoint (optional, default `{maxThrottleRetries:2}`)
+    -   `opt.noFlatten` **[boolean][79]?** do not flatten results
+    -   `opt.returnRaw` **[boolean][79]?** return only the raw data (may or may not be flattened)
+    -   `opt.saveRaw` **[string][76]?** filename to save raw data to (may or may not be flattened)
+    -   `opt.saveParsed` **[string][76]?** filename to save final parsed data to (not compatible with returnRaw, since parsing won't happen)
     -   `opt.maxThrottleRetries` **int** maximum number of retries for throttling (optional, default `2`)
 
 Returns **any** Results of the call to MWS
@@ -203,9 +206,9 @@ determine if flattenResult was called with an Array as the root
 
 **Parameters**
 
--   `type` **[string][73]** type of integer to validate (xs:int, xs:positiveInteger, etc)
+-   `type` **[string][76]** type of integer to validate (xs:int, xs:positiveInteger, etc)
 -   `test` **any** value to test
--   `minmax` **[object][71]** minimum and maximum values to test for (optional, default `{}`)
+-   `minmax` **[object][74]** minimum and maximum values to test for (optional, default `{}`)
     -   `minmax.minValue` **integer** minimum value to test for
     -   `minmax.maxValue` **integer** maximum value to test for
 
@@ -227,13 +230,13 @@ status indicators for report processing status updates
 
 **Parameters**
 
--   `marketplaceId` **[string][73]** id of marketplace. should be same as hash index.
--   `defaultCountryCode` **[string][73]** country code for marketplace (US, CA, etc)
--   `domainName` **[string][73]** domain name used by customers to access this market (amazon.com, .ca, .mx)
--   `defaultCurrencyCode` **[string][73]** currency code (USD, CAD, etc)
--   `defaultLanguageCode` **[string][73]** Language setting (en_US, en_CA, etc)
--   `sellerId` **[string][73]** your seller ID in this marketplace
--   `hasSellerSuspendedListings` **[boolean][76]** true if there are seller suspended listings in this account on this market
+-   `marketplaceId` **[string][76]** id of marketplace. should be same as hash index.
+-   `defaultCountryCode` **[string][76]** country code for marketplace (US, CA, etc)
+-   `domainName` **[string][76]** domain name used by customers to access this market (amazon.com, .ca, .mx)
+-   `defaultCurrencyCode` **[string][76]** currency code (USD, CAD, etc)
+-   `defaultLanguageCode` **[string][76]** Language setting (en_US, en_CA, etc)
+-   `sellerId` **[string][76]** your seller ID in this marketplace
+-   `hasSellerSuspendedListings` **[boolean][79]** true if there are seller suspended listings in this account on this market
 
 ## getMarketplaces
 
@@ -253,7 +256,7 @@ Returns **MarketDetail**
 
 ## parseMarketplaceData
 
-Turn a mess of XML from ListMarketplaceParticipations into a @see [MarketDetail][77]
+Turn a mess of XML from ListMarketplaceParticipations into a @see [MarketDetail][80]
 
 **Parameters**
 
@@ -261,9 +264,18 @@ Turn a mess of XML from ListMarketplaceParticipations into a @see [MarketDetail]
 
 ## listOrderItems
 
+**Parameters**
+
+-   `AmazonOrderId`  
+-   `orderId` **[string][76]** Amazon Order ID
+-   `nextToken` **[string][76]** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
+-   `orderItems` **[Array][81]** Array of all the items in the order
+
+## listOrderItems
+
 Returns order items based on the AmazonOrderId that you specify.
 
-If you've pulled a list of orders using @see [ListOrders][78], or have order identifiers
+If you've pulled a list of orders using @see [ListOrders][82], or have order identifiers
 stored in some other fashion, then to find out what items are actually on the orders, you will
 need to call ListOrderItems to obtain details about the items that were ordered.  The ListOrders
 call does not give you any information about the items, except how many of them have shipped or
@@ -277,18 +289,71 @@ ShippingDiscount
 
 **Parameters**
 
--   `AmazonOrderId` **[string][73]** 3-7-7 Amazon Order ID formatted string
+-   `AmazonOrderId` **[string][76]** 3-7-7 Amazon Order ID formatted string
 
 Returns **OrderItemList** 
 
-## listOrderItems
+## transformIntsAndBools
 
 **Parameters**
 
--   `AmazonOrderId`  
--   `orderId` **[string][73]** Amazon Order ID
--   `nextToken` **[string][73]** Token to provide to ListOrderItemsByNextToken if needed (no token = no need)
--   `orderItems` **[Array][79]** Array of all the items in the order
+-   `item`  
+-   `null-null` **orderItems** array of OrderItem
+-   `null-null` **nextToken** string for next token to provide to calls to ListOrderItemsByNextToken
+-   `null-null` **orderId** string with the Amazon Order ID
+
+## transformIntsAndBools
+
+**Parameters**
+
+-   `item`  
+
+## transformIntsAndBools
+
+**Parameters**
+
+-   `item`  
+
+## listOrders
+
+Return orders created or updated during a specific time frame
+see [https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_ListOrders.html][83]
+At least ONE of the search options (and maybe more depending on which ones you select) must be
+specified. Error messages may or may not return information on what parameters you are missing.
+If you are having trouble, see the official parameter documentation above.
+
+**Parameters**
+
+-   `options` **[object][74]** 
+    -   `options.MarketplaceId` **[Array][81]&lt;[string][76]>** Array of Marketplace IDs to search @see [MWS_MARKETPLACES][9]
+    -   `options.CreatedAfter` **[Date][84]?** Select orders created at or after the given Date
+    -   `options.CreatedBefore` **[Date][84]?** Select orders created at or before the given Date
+    -   `options.LastUpdatedAfter` **[Date][84]?** Select orders updated at or after the given Date
+    -   `options.LastUpdatedBefore` **[Date][84]?** Select orders updated at or before the given Date
+    -   `options.OrderStatus` **[string][76]?** OrderStatus, see MWS doc page
+    -   `options.FulfillmentChannel` **[string][76]?** AFN for Amazon fulfillment, MFN for merchant
+    -   `options.PaymentMethod` **[string][76]?** All, COD, CVS, Other
+    -   `options.BuyerEmail` **[string][76]?** Search for orders with given Email address
+    -   `options.SellerOrderId` **[string][76]?** Specified seller order ID
+    -   `options.MaxResultsPerPage` **[string][76]** Max number of results to return, 1 &lt;=> 100 (optional, default `100`)
+    -   `options.TFMShipmentStatus` **[string][76]?** See MWS doc page
+
+Returns **[object][74]** 
+
+## listFinancialEvents
+
+[https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html][85]
+
+**Parameters**
+
+-   `options` **[object][74]** 
+    -   `options.MaxResultsPerPage` **[number][78]** Maximum number of results to return (1 &lt;=> 100)
+    -   `options.AmazonOrderId` **[string][76]** An order number to search for
+    -   `options.FinancialEventGroupId` **[string][76]** Type of Financial Event to search for
+    -   `options.PostedAfter` **[Date][84]** When to search for events after
+    -   `options.PostedBefore` **[Date][84]** When to search for events prior to
+
+Returns **[object][74]** 
 
 ## forceArray
 
@@ -302,10 +367,10 @@ remove a string pattern from a string
 
 **Parameters**
 
--   `str` **[string][73]** string to remove pattern from
--   `pattern` **([string][73] | regex)** pattern to remove
+-   `str` **[string][76]** string to remove pattern from
+-   `pattern` **([string][76] | regex)** pattern to remove
 
-Returns **[string][73]** string with the pattern removed
+Returns **[string][76]** string with the pattern removed
 
 ## transformAttributeSetKey
 
@@ -338,60 +403,19 @@ to a much more readable:
 
 Returns **any** transformed object
 
-## listOrders
-
-Return orders created or updated during a specific time frame
-see [https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_ListOrders.html][80]
-At least ONE of the search options (and maybe more depending on which ones you select) must be
-specified. Error messages may or may not return information on what parameters you are missing.
-If you are having trouble, see the official parameter documentation above.
-
-**Parameters**
-
--   `options` **[object][71]** 
-    -   `options.MarketplaceId` **[Array][79]&lt;[string][73]>** Array of Marketplace IDs to search @see [MWS_MARKETPLACES][9]
-    -   `options.CreatedAfter` **[Date][81]?** Select orders created at or after the given Date
-    -   `options.CreatedBefore` **[Date][81]?** Select orders created at or before the given Date
-    -   `options.LastUpdatedAfter` **[Date][81]?** Select orders updated at or after the given Date
-    -   `options.LastUpdatedBefore` **[Date][81]?** Select orders updated at or before the given Date
-    -   `options.OrderStatus` **[string][73]?** OrderStatus, see MWS doc page
-    -   `options.FulfillmentChannel` **[string][73]?** AFN for Amazon fulfillment, MFN for merchant
-    -   `options.PaymentMethod` **[string][73]?** All, COD, CVS, Other
-    -   `options.BuyerEmail` **[string][73]?** Search for orders with given Email address
-    -   `options.SellerOrderId` **[string][73]?** Specified seller order ID
-    -   `options.MaxResultsPerPage` **[string][73]** Max number of results to return, 1 &lt;=> 100 (optional, default `100`)
-    -   `options.TFMShipmentStatus` **[string][73]?** See MWS doc page
-
-Returns **[object][71]** 
-
-## listFinancialEvents
-
-[https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html][82]
-
-**Parameters**
-
--   `options` **[object][71]** 
-    -   `options.MaxResultsPerPage` **[number][75]** Maximum number of results to return (1 &lt;=> 100)
-    -   `options.AmazonOrderId` **[string][73]** An order number to search for
-    -   `options.FinancialEventGroupId` **[string][73]** Type of Financial Event to search for
-    -   `options.PostedAfter` **[Date][81]** When to search for events after
-    -   `options.PostedBefore` **[Date][81]** When to search for events prior to
-
-Returns **[object][71]** 
-
 ## listInventorySupply
 
 Return information about the availability of a seller's FBA inventory
 
 **Parameters**
 
--   `options` **[object][71]** 
-    -   `options.SellerSkus` **[Array][79]&lt;[String][73]>** A list of SKUs for items to get inventory info for
-    -   `options.QueryStartDateTime` **[Date][81]** Date to begin searching at
-    -   `options.ResponseGroup` **[string][73]** 'Basic' = Do not include SupplyDetail, 'Detailed' = Do
-    -   `options.MarketplaceId` **[string][73]** Marketplace ID to search
+-   `options` **[object][74]** 
+    -   `options.SellerSkus` **[Array][81]&lt;[String][76]>** A list of SKUs for items to get inventory info for
+    -   `options.QueryStartDateTime` **[Date][84]** Date to begin searching at
+    -   `options.ResponseGroup` **[string][76]** 'Basic' = Do not include SupplyDetail, 'Detailed' = Do
+    -   `options.MarketplaceId` **[string][76]** Marketplace ID to search
 
-Returns **{nextToken: [string][73], supplyList: [Array][79]&lt;[object][71]>}** 
+Returns **{nextToken: [string][76], supplyList: [Array][81]&lt;[object][74]>}** 
 
 ## getMatchingProductForId
 
@@ -400,20 +424,12 @@ EAN, ISBN, or JAN values
 
 **Parameters**
 
--   `options` **[Object][71]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetMatchingProductForId.html][83]
-    -   `options.MarketplaceId` **[string][73]** Identifier for marketplace (see getMarketplaces)
-    -   `options.IdType` **[string][73]** Type of lookup to perform: ASIN, GCID, SellerSKU, UPC, EAN, ISBN, JAN
-    -   `options.IdList` **[Array][79]&lt;[string][73]>** List of codes to perform lookup on
+-   `options` **[Object][74]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetMatchingProductForId.html][86]
+    -   `options.MarketplaceId` **[string][76]** Identifier for marketplace (see getMarketplaces)
+    -   `options.IdType` **[string][76]** Type of lookup to perform: ASIN, GCID, SellerSKU, UPC, EAN, ISBN, JAN
+    -   `options.IdList` **[Array][81]&lt;[string][76]>** List of codes to perform lookup on
 
-Returns **[Array][79]&lt;Product>** 
-
-## getIdFromProductList
-
-**Parameters**
-
--   `productList`  
--   `type` **[string][73]** Type of Identifier used (asin, upc, ean, jan, etc)
--   `id` **[string][73]** Product Identifier string
+Returns **[Array][81]&lt;Product>** 
 
 ## getIdFromProductList
 
@@ -428,6 +444,14 @@ ListMatchingProduct does not return those, as you're not requesting a list of Id
 
 Returns **ProductIdentifier** 
 
+## getIdFromProductList
+
+**Parameters**
+
+-   `productList`  
+-   `type` **[string][76]** Type of Identifier used (asin, upc, ean, jan, etc)
+-   `id` **[string][76]** Product Identifier string
+
 ## parseMatchingProduct
 
 Parse MWS product info into Product\[] (TODO: document Product\[], it's quite a large potential result)
@@ -436,7 +460,7 @@ Parse MWS product info into Product\[] (TODO: document Product\[], it's quite a 
 
 -   `productData` **any** MWS product info
 
-Returns **[Array][79]&lt;Product>** 
+Returns **[Array][81]&lt;Product>** 
 
 ## getLowestPricedOffersForASIN
 
@@ -446,10 +470,10 @@ Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
 
 **Parameters**
 
--   `options` **[object][71]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html][84]
-    -   `options.MarketplaceId` **[string][73]** Marketplace ID to search
-    -   `options.ASIN` **[string][73]** ASIN to search for
-    -   `options.ItemCondition` **[string][73]** Listing Condition: New, Used, Collectible, Refurbished, Club
+-   `options` **[object][74]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html][87]
+    -   `options.MarketplaceId` **[string][76]** Marketplace ID to search
+    -   `options.ASIN` **[string][76]** ASIN to search for
+    -   `options.ItemCondition` **[string][76]** Listing Condition: New, Used, Collectible, Refurbished, Club
 
 Returns **LowestPricedOffers** 
 
@@ -461,10 +485,10 @@ Calls GetLowestPricedOffersForASIN, reformats results, and returns the data
 
 **Parameters**
 
--   `options` **[object][71]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html][84]
-    -   `options.MarketplaceId` **[string][73]** Marketplace ID to search
-    -   `options.SellerSKU` **[string][73]** SKU to search for
-    -   `options.ItemCondition` **[string][73]** Listing Condition: New, Used, Collectible, Refurbished, Club
+-   `options` **[object][74]** see [https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html][87]
+    -   `options.MarketplaceId` **[string][76]** Marketplace ID to search
+    -   `options.SellerSKU` **[string][76]** SKU to search for
+    -   `options.ItemCondition` **[string][76]** Listing Condition: New, Used, Collectible, Refurbished, Club
 
 Returns **LowestPricedOffers** 
 
@@ -473,71 +497,71 @@ Returns **LowestPricedOffers**
 **Parameters**
 
 -   `offerCount`  
--   `count` **[number][75]** 
--   `condition` **[string][73]** 
--   `fulfillmentChannel` **[string][73]** 
+-   `count` **[number][78]** 
+-   `condition` **[string][76]** 
+-   `fulfillmentChannel` **[string][76]** 
 
 ## reformatOffer
 
 **Parameters**
 
 -   `offer`  
--   `unknown` **[string][73]** 
+-   `unknown` **[string][76]** 
 
 ## reformatOffer
 
 **Parameters**
 
 -   `offer`  
--   `unknown` **[string][73]** 
+-   `unknown` **[string][76]** 
 
 ## reformatOffer
 
 **Parameters**
 
 -   `offer`  
--   `subCondition` **[string][73]** The subcondition of the item (New, Mint, Very Good, Good, Acceptable, Poor, Club, OEM, Warranty, Refurbished Warranty, Refurbished, Open Box, or Other)
+-   `unknown` **[string][76]** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `unknown` **[string][76]** 
+
+## reformatOffer
+
+**Parameters**
+
+-   `offer`  
+-   `subCondition` **[string][76]** The subcondition of the item (New, Mint, Very Good, Good, Acceptable, Poor, Club, OEM, Warranty, Refurbished Warranty, Refurbished, Open Box, or Other)
 -   `sellerFeedbackRating` **SellerFeedbackRating** Information about the seller's feedback
 -   `shippingTime` **DetailedShippingTime** Maximum time within which the item will likely be shipped
 -   `listingPrice` **Money** The price of the item
 -   `points` **Points?** The number of Amazon Points offered with the purchase of an item
 -   `shipping` **Money** Cost of shipping
 -   `shipsFrom` **ShipsFrom?** State and Country where item is shipped from
--   `isFulfilledByAmazon` **[boolean][76]** True if FBA, False if not
--   `isBuyBoxWinner` **[boolean][76]?** True if offer has buy box, False if not
--   `isFeaturedMerchant` **[boolean][76]?** True if seller is eligible for Buy Box, False if not
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string][73]** 
-
-## reformatOffer
-
-**Parameters**
-
--   `offer`  
--   `unknown` **[string][73]** 
+-   `isFulfilledByAmazon` **[boolean][79]** True if FBA, False if not
+-   `isBuyBoxWinner` **[boolean][79]?** True if offer has buy box, False if not
+-   `isFeaturedMerchant` **[boolean][79]?** True if seller is eligible for Buy Box, False if not
 
 ## reformatLowestPrice
 
 **Parameters**
 
 -   `lp`  
--   `condition` **[string][73]** 
--   `fulfillmentChannel` **[string][73]** 
+-   `condition` **[string][76]** 
+-   `fulfillmentChannel` **[string][76]** 
 -   `landedPrice` **Money** 
 -   `listingPrice` **Money** 
--   `shipping` **[string][73]** 
+-   `shipping` **[string][76]** 
 
 ## reformatBuyBoxPrice
 
 **Parameters**
 
 -   `bb`  
--   `condition` **[string][73]** 
+-   `condition` **[string][76]** 
 -   `landedPrice` **Money** 
 -   `listingPrice` **Money** 
 -   `shipping` **Money** 
@@ -547,22 +571,22 @@ Returns **LowestPricedOffers**
 **Parameters**
 
 -   `summary`  
--   `totalOfferCount` **[number][75]** 
--   `numberOfOffers` **[number][75]** 
+-   `totalOfferCount` **[number][78]** 
+-   `numberOfOffers` **[number][78]** 
 -   `listPrice` **Money** 
--   `lowestPrices` **[Array][79]&lt;LowestPrice>** 
--   `buyBoxPrices` **[Array][79]** 
+-   `lowestPrices` **[Array][81]&lt;LowestPrice>** 
+-   `buyBoxPrices` **[Array][81]** 
 
 ## parseLowestPricedOffers
 
 **Parameters**
 
 -   `offerData`  
--   `asin` **[string][73]** asin returned by request
--   `marketplace` **[string][73]** marketplace asin is in
--   `itemCondition` **[string][73]** condition of item requested
+-   `asin` **[string][76]** asin returned by request
+-   `marketplace` **[string][76]** marketplace asin is in
+-   `itemCondition` **[string][76]** condition of item requested
 -   `summary` **OfferSummary** \-
--   `offers` **[Array][79]&lt;Offers>** list of offers
+-   `offers` **[Array][81]&lt;Offers>** list of offers
 
 ## getProductCategoriesForAsins
 
@@ -571,23 +595,34 @@ Product Category Information
 
 **Parameters**
 
--   `$0` **[Object][71]** 
+-   `$0` **[Object][74]** 
     -   `$0.marketplaceId`  
     -   `$0.asins`  
--   `ProductCategoryId` **[string][73]** The string or numeric-string category identifier for the category
--   `ProductCategoryName` **[string][73]** The string human readable description of the category
+-   `ProductCategoryId` **[string][76]** The string or numeric-string category identifier for the category
+-   `ProductCategoryName` **[string][76]** The string human readable description of the category
 -   `Parent` **productCategory?** Parent product category. This will not be present if this category is the root.
 
 ## getProductCategoriesForAsins
 
 **Parameters**
 
--   `$0` **[Object][71]** 
+-   `$0` **[Object][74]** 
     -   `$0.marketplaceId`  
     -   `$0.asins`  
--   `asin` **[string][73]** ASIN that this category information belongs to
--   `error` **[object][71]?** This field is set when a server error is returned, see error.code and error.body for further info. Server Errors may be returned for invalid ASINs or other reasons.
+-   `asin` **[string][76]** ASIN that this category information belongs to
+-   `error` **[object][74]?** This field is set when a server error is returned, see error.code and error.body for further info. Server Errors may be returned for invalid ASINs or other reasons.
 -   `Self` **productCategory?** The product category this ASIN belongs to - if not present, may be an invalid ASIN
+
+## getProductCategoriesForAsins
+
+**Parameters**
+
+-   `$0` **[Object][74]** 
+    -   `$0.marketplaceId`  
+    -   `$0.asins`  
+-   `sku` **[string][76]** SKU that this category information belongs to
+-   `error` **[object][74]?** This field is set when a server error is returned, see error.code and error.body for further info. Server Errors may be returned for invalid SKUs or other reasons.
+-   `Self` **productCategory?** The product category that this SKU belongs to - if not present, may be an invalid ASIN
 
 ## getProductCategoriesForAsins
 
@@ -595,22 +630,11 @@ return product categories for multiple asins
 
 **Parameters**
 
--   `parameters` **[object][71]** 
-    -   `parameters.marketplaceId` **[string][73]** marketplace identifier to run query on
-    -   `parameters.asins` **[Array][79]&lt;[string][73]>** Array of string ASINs to query for
+-   `parameters` **[object][74]** 
+    -   `parameters.marketplaceId` **[string][76]** marketplace identifier to run query on
+    -   `parameters.asins` **[Array][81]&lt;[string][76]>** Array of string ASINs to query for
 
-Returns **[Array][79]&lt;productCategoryByAsin>** Array of product category information
-
-## getProductCategoriesForAsins
-
-**Parameters**
-
--   `$0` **[Object][71]** 
-    -   `$0.marketplaceId`  
-    -   `$0.asins`  
--   `sku` **[string][73]** SKU that this category information belongs to
--   `error` **[object][71]?** This field is set when a server error is returned, see error.code and error.body for further info. Server Errors may be returned for invalid SKUs or other reasons.
--   `Self` **productCategory?** The product category that this SKU belongs to - if not present, may be an invalid ASIN
+Returns **[Array][81]&lt;productCategoryByAsin>** Array of product category information
 
 ## getProductCategoriesForSkus
 
@@ -618,62 +642,11 @@ return product categories for multiple asins
 
 **Parameters**
 
--   `parameters` **[object][71]** 
-    -   `parameters.marketplaceId` **[string][73]** marketplace identifier to run query on
-    -   `parameters.skus` **[Array][79]&lt;[string][73]>** Array of string SKUs to query for
+-   `parameters` **[object][74]** 
+    -   `parameters.marketplaceId` **[string][76]** marketplace identifier to run query on
+    -   `parameters.skus` **[Array][81]&lt;[string][76]>** Array of string SKUs to query for
 
-Returns **[Array][79]&lt;productCategoryBySku>** Array of product category information
-
-## getMyFeesEstimate
-
-**Parameters**
-
--   `estimates`  
--   `marketplaceId` **[string][73]** MWS MarketplaceId requested
--   `idType` **[string][73]** type of identifier requested
--   `sellerId` **[string][73]** the seller identifier that requested the estimate
--   `isAmazonFulfilled` **[boolean][76]** true for FBA, false for Merchant Fulfilled
--   `sellerInputIdentifier` **[string][73]** identifier from EstimateRequest
--   `idValue` **[string][73]** the product idValue from EstimateRequest
--   `priceToEstimateFees` **[object][71]** Money values entered in as listingPrice and shipping to EstimateRequest
-    -   `priceToEstimateFees.listingPrice` **Money** listingPrice from EstimateRequest
-    -   `priceToEstimateFees.shipping` **Money** shipping from EstimateRequest
-
-## getMyFeesEstimate
-
-**Parameters**
-
--   `estimates`  
--   `marketplaceId` **[string][73]** MWS MarketplaceId to request item within
--   `idType` **[string][73]** type of identifier for item (ASIN, GCID, SellerSKU, UPC, EAN, ISBN, JAN)
--   `idValue` **[string][73]** identifier to use (see idType)
--   `isAmazonFulfilled` **[boolean][76]** true for FBA fees, false for Merchant Fulfilled fees
--   `listingPrice` **Money** currencyCode and amount for listing price
--   `shipping` **Money** currencyCode and amount for shipping price
--   `points` **[object][71]** pointsNumber: amazon points for purchase (Japan only?)
--   `identifier` **[string][73]?** identifier to attach to request. If not given, will be `FBA.${idValue}` for FBA requests or `MF.${idValue}` for MF requests
-
-## getMyFeesEstimate
-
-**Parameters**
-
--   `estimates`  
--   `totalFees` **Money** currencyCode and amount for total fees
--   `time` **[string][73]** ISO8601 time stamp format time the fee response was created
--   `detail` **[Array][79]&lt;FeeDetail>** array of details about each of the fees that make up totalFees
--   `identifier` **FeeIdentifier** information about the EstimateRequest
--   `status` **[string][73]** "Success" for success or "ServerError" for request failure
--   `error` **[Error][85]?** If an Error occurred (success === "Failure"), a description of the Error
-
-## getMyFeesEstimate
-
-**Parameters**
-
--   `estimates`  
--   `feeType` **[string][73]** The type of fee (ReferralFee, PerItemFee, VariableClosingFee, etc)
--   `feeAmount` **Money** Base fee, currencyCode and amount
--   `feePromotion` **Money** Discounts applied to fee, currencyCode and amount
--   `finalFee` **Money** feeAmount minus feePromotion, currencyCode and amount
+Returns **[Array][81]&lt;productCategoryBySku>** Array of product category information
 
 ## getMyFeesEstimate
 
@@ -682,9 +655,60 @@ Get an estimate of fees for an item, based on listing and shipping prices.
 **Parameters**
 
 -   `estimates`  
--   `null-null` **[Array][79]&lt;EstimateRequest>** Array of EstimateRequest items to get fees for
+-   `null-null` **[Array][81]&lt;EstimateRequest>** Array of EstimateRequest items to get fees for
 
-Returns **[Object][71]** Object of Estimate items, indexed by EstimateRequest Identifier
+Returns **[Object][74]** Object of Estimate items, indexed by EstimateRequest Identifier
+
+## getMyFeesEstimate
+
+**Parameters**
+
+-   `estimates`  
+-   `marketplaceId` **[string][76]** MWS MarketplaceId to request item within
+-   `idType` **[string][76]** type of identifier for item (ASIN, GCID, SellerSKU, UPC, EAN, ISBN, JAN)
+-   `idValue` **[string][76]** identifier to use (see idType)
+-   `isAmazonFulfilled` **[boolean][79]** true for FBA fees, false for Merchant Fulfilled fees
+-   `listingPrice` **Money** currencyCode and amount for listing price
+-   `shipping` **Money** currencyCode and amount for shipping price
+-   `points` **[object][74]** pointsNumber: amazon points for purchase (Japan only?)
+-   `identifier` **[string][76]?** identifier to attach to request. If not given, will be `FBA.${idValue}` for FBA requests or `MF.${idValue}` for MF requests
+
+## getMyFeesEstimate
+
+**Parameters**
+
+-   `estimates`  
+-   `totalFees` **Money** currencyCode and amount for total fees
+-   `time` **[string][76]** ISO8601 time stamp format time the fee response was created
+-   `detail` **[Array][81]&lt;FeeDetail>** array of details about each of the fees that make up totalFees
+-   `identifier` **FeeIdentifier** information about the EstimateRequest
+-   `status` **[string][76]** "Success" for success or "ServerError" for request failure
+-   `error` **[Error][88]?** If an Error occurred (success === "Failure"), a description of the Error
+
+## getMyFeesEstimate
+
+**Parameters**
+
+-   `estimates`  
+-   `feeType` **[string][76]** The type of fee (ReferralFee, PerItemFee, VariableClosingFee, etc)
+-   `feeAmount` **Money** Base fee, currencyCode and amount
+-   `feePromotion` **Money** Discounts applied to fee, currencyCode and amount
+-   `finalFee` **Money** feeAmount minus feePromotion, currencyCode and amount
+
+## getMyFeesEstimate
+
+**Parameters**
+
+-   `estimates`  
+-   `marketplaceId` **[string][76]** MWS MarketplaceId requested
+-   `idType` **[string][76]** type of identifier requested
+-   `sellerId` **[string][76]** the seller identifier that requested the estimate
+-   `isAmazonFulfilled` **[boolean][79]** true for FBA, false for Merchant Fulfilled
+-   `sellerInputIdentifier` **[string][76]** identifier from EstimateRequest
+-   `idValue` **[string][76]** the product idValue from EstimateRequest
+-   `priceToEstimateFees` **[object][74]** Money values entered in as listingPrice and shipping to EstimateRequest
+    -   `priceToEstimateFees.listingPrice` **Money** listingPrice from EstimateRequest
+    -   `priceToEstimateFees.shipping` **Money** shipping from EstimateRequest
 
 ## listMatchingProducts
 
@@ -692,12 +716,12 @@ Return a list of products and their attributes, based on a text query and contex
 
 **Parameters**
 
--   `options` **[object][71]** 
-    -   `options.marketplaceId` **[string][73]** marketplace identifier to search
-    -   `options.query` **[string][73]** a search string "with the same support as that provided on Amazon marketplace websites"
-    -   `options.queryContextId` **[string][73]?** context in which to limit search. Not specified will mean "search everywhere". See [https://docs.developer.amazonservices.com/en_UK/products/Products_QueryContextIDs.html][86]
+-   `options` **[object][74]** 
+    -   `options.marketplaceId` **[string][76]** marketplace identifier to search
+    -   `options.query` **[string][76]** a search string "with the same support as that provided on Amazon marketplace websites"
+    -   `options.queryContextId` **[string][76]?** context in which to limit search. Not specified will mean "search everywhere". See [https://docs.developer.amazonservices.com/en_UK/products/Products_QueryContextIDs.html][89]
 
-Returns **[Array][79]&lt;Product>** Array of product information
+Returns **[Array][81]&lt;Product>** Array of product information
 
 ## writeFile
 
@@ -708,52 +732,37 @@ This is better than using writeFileSync. Trust me. :-)
 
 **Parameters**
 
--   `fileName` **[string][73]** path/filename to write to
--   `contents` **([string][73] \| [Buffer][87])** what to write to file
+-   `fileName` **[string][76]** path/filename to write to
+-   `contents` **([string][76] \| [Buffer][90])** what to write to file
 
 ## requestReport
 
 **Parameters**
 
 -   `options`  
--   `ReportType` **[string][73]** Type of Report Requested @see [REQUEST_REPORT_TYPES][20]
--   `ReportProcessingStatus` **[string][73]** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES][21]
--   `EndDate` **[string][73]** ISO Date for Date Ending period
--   `Scheduled` **[boolean][76]** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string][73]** Identifier to use with getReport to fetch the report when ready
--   `SubmittedDate` **[string][73]** ISO Date for Date request was submitted
--   `StartDate` **[string][73]** ISO Date for Date report begins at
+-   `ReportType` **[string][76]** Type of Report Requested @see [REQUEST_REPORT_TYPES][20]
+-   `ReportProcessingStatus` **[string][76]** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES][21]
+-   `EndDate` **[string][76]** ISO Date for Date Ending period
+-   `Scheduled` **[boolean][79]** True if report is scheduled, false if immediate
+-   `ReportRequestId` **[string][76]** Identifier to use with getReport to fetch the report when ready
+-   `SubmittedDate` **[string][76]** ISO Date for Date request was submitted
+-   `StartDate` **[string][76]** ISO Date for Date report begins at
 
 ## requestReport
 
 Request a report from MWS
-Many optional parameters may be required by MWS! Read [ReportType][88] for specifics!
+Many optional parameters may be required by MWS! Read [ReportType][91] for specifics!
 
 **Parameters**
 
--   `options` **[object][71]** 
-    -   `options.ReportType` **[string][73]** Type of Report to Request @see [REQUEST_REPORT_TYPES][20]
-    -   `options.StartDate` **[Date][81]?** Date to start report
-    -   `options.EndDate` **[Date][81]?** Date to end report at
-    -   `options.ReportOptions` **[object][71]?** Reports may have additional options available. Please see the [ReportType][88] official docs
--   `MarketplaceId` **[Array][79]&lt;[string][73]>?** Array of marketplace IDs to generate reports covering
+-   `options` **[object][74]** 
+    -   `options.ReportType` **[string][76]** Type of Report to Request @see [REQUEST_REPORT_TYPES][20]
+    -   `options.StartDate` **[Date][84]?** Date to start report
+    -   `options.EndDate` **[Date][84]?** Date to end report at
+    -   `options.ReportOptions` **[object][74]?** Reports may have additional options available. Please see the [ReportType][91] official docs
+-   `MarketplaceId` **[Array][81]&lt;[string][76]>?** Array of marketplace IDs to generate reports covering
 
 Returns **ReportRequestInfo** 
-
-## getReportRequestList
-
-**Parameters**
-
--   `options`   (optional, default `{}`)
--   `ReportType` **[string][73]** Type of Report Requested @see [REQUEST_REPORT_TYPES][20]
--   `ReportProcessingStatus` **[string][73]** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES][21]
--   `EndDate` **[string][73]** ISO Date for Report End Period
--   `Scheduled` **[boolean][76]** True if report is scheduled, false if immediate
--   `ReportRequestId` **[string][73]** Identifier for the Report Request
--   `StartedProcessingDate` **[string][73]** ISO Date for time MWS started processing request
--   `StartDate` **[string][73]** ISO Date for Report Start Period
--   `CompletedDate` **[string][73]** ISO Date for time MWS completed processing request
--   `GeneratedReportId` **[string][73]** Identifier to use with getReport to retrieve the report
 
 ## getReportRequestList
 
@@ -763,15 +772,30 @@ has been processed.
 
 **Parameters**
 
--   `options` **[object][71]?** Options to pass to GetReportRequestList (optional, default `{}`)
--   `ReportRequestIdList` **[Array][79]&lt;[string][73]>?** List of report request IDs @see [requestReport][62]
--   `ReportTypeList` **[Array][79]&lt;[string][73]>?** List of Report Types @see [REQUEST_REPORT_TYPES][20]
--   `ReportProcessingStatusList` **[Array][79]&lt;[string][73]>?** List of Report Processing Status @see [REPORT_PROCESSING_STATUS_TYPES][21]
--   `MaxCount` **[number][75]** Maximum number of report requests to return, max is 100 (optional, default `10`)
--   `RequestedFromDate` **[Date][81]** Oldest date to search for (optional, default `90-days-past`)
--   `RequestedToDate` **[Date][81]** Newest date to search for (optional, default `Now`)
+-   `options` **[object][74]?** Options to pass to GetReportRequestList (optional, default `{}`)
+-   `ReportRequestIdList` **[Array][81]&lt;[string][76]>?** List of report request IDs @see [requestReport][65]
+-   `ReportTypeList` **[Array][81]&lt;[string][76]>?** List of Report Types @see [REQUEST_REPORT_TYPES][20]
+-   `ReportProcessingStatusList` **[Array][81]&lt;[string][76]>?** List of Report Processing Status @see [REPORT_PROCESSING_STATUS_TYPES][21]
+-   `MaxCount` **[number][78]** Maximum number of report requests to return, max is 100 (optional, default `10`)
+-   `RequestedFromDate` **[Date][84]** Oldest date to search for (optional, default `90-days-past`)
+-   `RequestedToDate` **[Date][84]** Newest date to search for (optional, default `Now`)
 
-Returns **[Array][79]&lt;GetReportRequestListResult>** 
+Returns **[Array][81]&lt;GetReportRequestListResult>** 
+
+## getReportRequestList
+
+**Parameters**
+
+-   `options`   (optional, default `{}`)
+-   `ReportType` **[string][76]** Type of Report Requested @see [REQUEST_REPORT_TYPES][20]
+-   `ReportProcessingStatus` **[string][76]** Status of Report @see [REPORT_PROCESSING_STATUS_TYPES][21]
+-   `EndDate` **[string][76]** ISO Date for Report End Period
+-   `Scheduled` **[boolean][79]** True if report is scheduled, false if immediate
+-   `ReportRequestId` **[string][76]** Identifier for the Report Request
+-   `StartedProcessingDate` **[string][76]** ISO Date for time MWS started processing request
+-   `StartDate` **[string][76]** ISO Date for Report Start Period
+-   `CompletedDate` **[string][76]** ISO Date for time MWS completed processing request
+-   `GeneratedReportId` **[string][76]** Identifier to use with getReport to retrieve the report
 
 ## getReport
 
@@ -779,10 +803,10 @@ Returns the contents of a report
 
 **Parameters**
 
--   `options` **[object][71]** Options to pass to GetReport
-    -   `options.ReportId` **[string][73]** Report number from @see [GetReportList][89] or GeneratedReportId from @see [GetReportRequestListResult][90]
+-   `options` **[object][74]** Options to pass to GetReport
+    -   `options.ReportId` **[string][76]** Report number from @see [GetReportList][92] or GeneratedReportId from @see [GetReportRequestListResult][93]
 
-Returns **([Array][79] \| [object][71])** Contents of the report to return (format may vary WIDELY between different reports generated, see [ReportType][88])
+Returns **([Array][81] \| [object][74])** Contents of the report to return (format may vary WIDELY between different reports generated, see [ReportType][91])
 
 ## getReportList
 
@@ -872,130 +896,136 @@ TODO: Document requestAndDownloadReport
 
 [26]: #listorderitems-1
 
-[27]: #forcearray
+[27]: #transformintsandbools
 
-[28]: #removefromstring
+[28]: #transformintsandbools-1
 
-[29]: #transformattributesetkey
+[29]: #transformintsandbools-2
 
-[30]: #transformobjectkeys
+[30]: #listorders
 
-[31]: #listorders
+[31]: #listfinancialevents
 
-[32]: #listfinancialevents
+[32]: #forcearray
 
-[33]: #listinventorysupply
+[33]: #removefromstring
 
-[34]: #getmatchingproductforid
+[34]: #transformattributesetkey
 
-[35]: #getidfromproductlist
+[35]: #transformobjectkeys
 
-[36]: #getidfromproductlist-1
+[36]: #listinventorysupply
 
-[37]: #parsematchingproduct
+[37]: #getmatchingproductforid
 
-[38]: #getlowestpricedoffersforasin
+[38]: #getidfromproductlist
 
-[39]: #getlowestpricedoffersforsku
+[39]: #getidfromproductlist-1
 
-[40]: #reformatoffercount
+[40]: #parsematchingproduct
 
-[41]: #reformatoffer
+[41]: #getlowestpricedoffersforasin
 
-[42]: #reformatoffer-1
+[42]: #getlowestpricedoffersforsku
 
-[43]: #reformatoffer-2
+[43]: #reformatoffercount
 
-[44]: #reformatoffer-3
+[44]: #reformatoffer
 
-[45]: #reformatoffer-4
+[45]: #reformatoffer-1
 
-[46]: #reformatlowestprice
+[46]: #reformatoffer-2
 
-[47]: #reformatbuyboxprice
+[47]: #reformatoffer-3
 
-[48]: #reformatsummary
+[48]: #reformatoffer-4
 
-[49]: #parselowestpricedoffers
+[49]: #reformatlowestprice
 
-[50]: #getproductcategoriesforasins
+[50]: #reformatbuyboxprice
 
-[51]: #getproductcategoriesforasins-1
+[51]: #reformatsummary
 
-[52]: #getproductcategoriesforasins-2
+[52]: #parselowestpricedoffers
 
-[53]: #getproductcategoriesforasins-3
+[53]: #getproductcategoriesforasins
 
-[54]: #getproductcategoriesforskus
+[54]: #getproductcategoriesforasins-1
 
-[55]: #getmyfeesestimate
+[55]: #getproductcategoriesforasins-2
 
-[56]: #getmyfeesestimate-1
+[56]: #getproductcategoriesforasins-3
 
-[57]: #getmyfeesestimate-2
+[57]: #getproductcategoriesforskus
 
-[58]: #getmyfeesestimate-3
+[58]: #getmyfeesestimate
 
-[59]: #getmyfeesestimate-4
+[59]: #getmyfeesestimate-1
 
-[60]: #listmatchingproducts
+[60]: #getmyfeesestimate-2
 
-[61]: #writefile
+[61]: #getmyfeesestimate-3
 
-[62]: #requestreport
+[62]: #getmyfeesestimate-4
 
-[63]: #requestreport-1
+[63]: #listmatchingproducts
 
-[64]: #getreportrequestlist
+[64]: #writefile
 
-[65]: #getreportrequestlist-1
+[65]: #requestreport
 
-[66]: #getreport
+[66]: #requestreport-1
 
-[67]: #getreportlist
+[67]: #getreportrequestlist
 
-[68]: #getreportlistbynexttoken
+[68]: #getreportrequestlist-1
 
-[69]: #getreportlistall
+[69]: #getreport
 
-[70]: #requestanddownloadreport
+[70]: #getreportlist
 
-[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[71]: #getreportlistbynexttoken
 
-[72]: #mwsadvanced
+[72]: #getreportlistall
 
-[73]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[73]: #requestanddownloadreport
 
-[74]: https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html
+[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[75]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[75]: #mwsadvanced
 
-[76]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[76]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[77]: MarketDetail
+[77]: https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Endpoints.html
 
-[78]: ListOrders
+[78]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[79]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[79]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[80]: https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_ListOrders.html
+[80]: MarketDetail
 
-[81]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
+[81]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[82]: https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html
+[82]: ListOrders
 
-[83]: https://docs.developer.amazonservices.com/en_UK/products/Products_GetMatchingProductForId.html
+[83]: https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_ListOrders.html
 
-[84]: https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html
+[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
 
-[85]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
+[85]: https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html
 
-[86]: https://docs.developer.amazonservices.com/en_UK/products/Products_QueryContextIDs.html
+[86]: https://docs.developer.amazonservices.com/en_UK/products/Products_GetMatchingProductForId.html
 
-[87]: https://nodejs.org/api/buffer.html
+[87]: https://docs.developer.amazonservices.com/en_UK/products/Products_GetLowestPricedOffersForASIN.html
 
-[88]: https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html
+[88]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
 
-[89]: GetReportList
+[89]: https://docs.developer.amazonservices.com/en_UK/products/Products_QueryContextIDs.html
 
-[90]: GetReportRequestListResult
+[90]: https://nodejs.org/api/buffer.html
+
+[91]: https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html
+
+[92]: GetReportList
+
+[93]: GetReportRequestListResult

--- a/docs/badge.svg
+++ b/docs/badge.svg
@@ -11,7 +11,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="32" y="15" fill="#010101" fill-opacity=".3">document</text>
     <text x="32" y="14">document</text>
-    <text x="84" y="15" fill="#010101" fill-opacity=".3">53%</text>
-    <text x="84" y="14">53%</text>
+    <text x="84" y="15" fill="#010101" fill-opacity=".3">51%</text>
+    <text x="84" y="14">51%</text>
   </g>
 </svg>

--- a/docs/class/lib/errors.js~InvalidIdentifier.html
+++ b/docs/class/lib/errors.js~InvalidIdentifier.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/class/lib/errors.js~InvalidUsage.html
+++ b/docs/class/lib/errors.js~InvalidUsage.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/class/lib/errors.js~RequestCancelled.html
+++ b/docs/class/lib/errors.js~RequestCancelled.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/class/lib/errors.js~ServiceError.html
+++ b/docs/class/lib/errors.js~ServiceError.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/class/lib/errors.js~ValidationError.html
+++ b/docs/class/lib/errors.js~ValidationError.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/callEndpoint.js.html
+++ b/docs/file/lib/callEndpoint.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/constants.js.html
+++ b/docs/file/lib/constants.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/dig-response-result.js.html
+++ b/docs/file/lib/dig-response-result.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/constants.js.html
+++ b/docs/file/lib/endpoints/constants.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/endpoints-utils.js.html
+++ b/docs/file/lib/endpoints/endpoints-utils.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -102,25 +105,25 @@
  * @returns
  */
 const generateEndpoints = (categoryName, version, endpoints, endpointDetails) =&gt; {
-    const ret = {};
-    endpoints.forEach((endpoint) =&gt; {
+    const ret = endpoints.reduce((acc, endpoint) =&gt; {
         let index = endpoint;
-        if (ret[endpoint]) { // TODO: Code coverage is not hitting this if. Is this worrying about a problem with each category having GetServiceStatus, that doesn&apos;t exist? need to test GetServiceStatus everywhere I guess, and see if this if is necessary.
+        if (acc[endpoint]) { // TODO: Code coverage is not hitting this if. Is this worrying about a problem with each category having GetServiceStatus, that doesn&apos;t exist? need to test GetServiceStatus everywhere I guess, and see if this if is necessary.
             index = `${categoryName}/${endpoint}`;
         }
-        ret[index] = {
+        const d = (endpointDetails &amp;&amp; endpointDetails[endpoint]) || {};
+
+        const { params, returns, throttle } = d;
+
+        acc[index] = {
             category: categoryName,
             version,
             action: endpoint,
+            params,
+            returns,
+            throttle,
         };
-        if (endpointDetails &amp;&amp; endpointDetails[endpoint]) {
-            const d = endpointDetails[endpoint];
-            if (d.params) ret[index].params = d.params;
-            if (d.returns) ret[index].returns = d.returns;
-            if (d.throttle) ret[index].throttle = d.throttle;
-        }
-    });
-    // console.warn(&apos;***** generateEndpoints&apos;, JSON.stringify(ret));
+        return acc;
+    }, {});
     return ret;
 };
 

--- a/docs/file/lib/endpoints/feeds.js.html
+++ b/docs/file/lib/endpoints/feeds.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/finances.js.html
+++ b/docs/file/lib/endpoints/finances.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/inbound.js.html
+++ b/docs/file/lib/endpoints/inbound.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/index.js.html
+++ b/docs/file/lib/endpoints/index.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/inventory.js.html
+++ b/docs/file/lib/endpoints/inventory.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/merch-fulfillment.js.html
+++ b/docs/file/lib/endpoints/merch-fulfillment.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/orders.js.html
+++ b/docs/file/lib/endpoints/orders.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/outbound.js.html
+++ b/docs/file/lib/endpoints/outbound.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/products.js.html
+++ b/docs/file/lib/endpoints/products.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/reports.js.html
+++ b/docs/file/lib/endpoints/reports.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/endpoints/sellers.js.html
+++ b/docs/file/lib/endpoints/sellers.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/errors.js.html
+++ b/docs/file/lib/errors.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/feeds/ListingLoader.js.html
+++ b/docs/file/lib/feeds/ListingLoader.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/flatten-result.js.html
+++ b/docs/file/lib/flatten-result.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/get-lowest-priced-offers.js.html
+++ b/docs/file/lib/get-lowest-priced-offers.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/get-marketplaces.js.html
+++ b/docs/file/lib/get-marketplaces.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/get-matching-product.js.html
+++ b/docs/file/lib/get-matching-product.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/get-my-fees-estimate.js.html
+++ b/docs/file/lib/get-my-fees-estimate.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/get-product-categories.js.html
+++ b/docs/file/lib/get-product-categories.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/list-financial-events.js.html
+++ b/docs/file/lib/list-financial-events.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/list-inventory-supply.js.html
+++ b/docs/file/lib/list-inventory-supply.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/list-matching-products.js.html
+++ b/docs/file/lib/list-matching-products.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/list-order-items.js.html
+++ b/docs/file/lib/list-order-items.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -93,9 +96,8 @@
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">/**
  * @module mws-advanced
  */
-const { callEndpoint } = require(&apos;./callEndpoint&apos;);
-const { digResponseResult } = require(&apos;./dig-response-result&apos;);
-const { forceArray } = require(&apos;./util/transformers&apos;);
+const { parseEndpoint } = require(&apos;./callEndpoint&apos;);
+const parseOrderItems = require(&apos;./parsers/orderItems&apos;);
 
 // TODO: make a typedef for OrderItem and document it correctly
 /**
@@ -132,15 +134,8 @@ const { forceArray } = require(&apos;./util/transformers&apos;);
  * @returns {OrderItemList}
  */
 const listOrderItems = async (AmazonOrderId) =&gt; {
-    const res = digResponseResult(&apos;ListOrderItems&apos;, await callEndpoint(&apos;ListOrderItems&apos;, { AmazonOrderId }));
-    const arr = forceArray(res.OrderItems);
-    const meh = arr.map(x =&gt; x.OrderItem);
-    const ret = {
-        nextToken: res.nextToken,
-        orderId: res.AmazonOrderId,
-        orderItems: meh,
-    };
-    return ret;
+    const results = await parseEndpoint(&apos;ListOrderItems&apos;, { AmazonOrderId })(parseOrderItems);
+    return results;
 };
 
 module.exports = {

--- a/docs/file/lib/list-orders.js.html
+++ b/docs/file/lib/list-orders.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/parsers/feesEstimate.js.html
+++ b/docs/file/lib/parsers/feesEstimate.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -92,25 +95,51 @@
 <div class="content" data-ice="content"><h1 data-ice="title">lib/parsers/feesEstimate.js</h1>
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const { forceArray, transformObjectKeys } = require(&apos;../util/transformers&apos;);
 
+function getFeesEstimate(e) {
+    return e.FeesEstimate || { TotalFeesEstimate: undefined, time: undefined, detail: undefined };
+}
+
+function getIdentifierData(e) {
+    return e.FeesEstimateIdentifier;
+}
+
+function getSellerInputIdentifier(e) {
+    return getIdentifierData(e).SellerInputIdentifier;
+}
+
+function getTotalFeesEstimate(e) {
+    return getFeesEstimate(e).TotalFeesEstimate;
+}
+
+function getTimeOfFeesEstimation(e) {
+    return getFeesEstimate(e).TimeOfFeesEstimation;
+}
+
+function getFeeDetailList(e) {
+    const list = getFeesEstimate(e).FeeDetailList;
+    return list ? forceArray(list) : undefined;
+}
+
 function parseFeesEstimate(fees) {
     const res2 = forceArray(fees.FeesEstimateResultList.FeesEstimateResult);
+    const feeList = res2.reduce((acc, e) =&gt; {
+        const sellerIdentifier = getSellerInputIdentifier(e);
+        const identifierData = { ...getIdentifierData(e) };
 
-    const ret = {};
-    res2.forEach((e) =&gt; {
-        const est = e.FeesEstimate || { TotalFeesEstimate: undefined, time: undefined, detail: undefined };
-        const identifierData = { ...e.FeesEstimateIdentifier };
-        const { SellerInputIdentifier: sellerIdentifier } = identifierData;
         identifierData.IsAmazonFulfilled = identifierData.IsAmazonFulfilled === &apos;true&apos;;
-        ret[sellerIdentifier] = {
-            totalFees: est.TotalFeesEstimate,
-            time: est.TimeOfFeesEstimation,
-            detail: est.FeeDetailList ? forceArray(est.FeeDetailList.FeeDetail) : undefined,
+
+        acc[sellerIdentifier] = {
+            totalFees: getTotalFeesEstimate(e),
+            time: getTimeOfFeesEstimation(e),
+            detail: getFeeDetailList(e),
             identifier: identifierData,
             status: e.Status,
             error: e.Error || undefined,
         };
-    });
-    return transformObjectKeys(ret);
+        return acc;
+    }, {});
+
+    return transformObjectKeys(feeList);
 }
 
 module.exports = parseFeesEstimate;

--- a/docs/file/lib/parsers/lowestPricedOffers.js.html
+++ b/docs/file/lib/parsers/lowestPricedOffers.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -195,7 +198,8 @@ const reformatLowestPrice = lp =&gt; ({
     shipping: lp.Shipping,
 });
 
-/** @typedef BuyBoxPrice
+/**
+ * @typedef BuyBoxPrice
  * @param {string} condition
  * @param {Money} landedPrice
  * @param {Money} listingPrice

--- a/docs/file/lib/parsers/marketplaceData.js.html
+++ b/docs/file/lib/parsers/marketplaceData.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/parsers/matchingProduct.js.html
+++ b/docs/file/lib/parsers/matchingProduct.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/parsers/orderItems.js.html
+++ b/docs/file/lib/parsers/orderItems.js.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">lib/reports.js | mws-advanced</title>
+  <base data-ice="baseUrl" href="../../../">
+  <title data-ice="title">lib/parsers/orderItems.js | mws-advanced</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
@@ -92,270 +92,67 @@
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1 data-ice="title">lib/reports.js</h1>
-<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">/** reporting functions
- * @module mws-advanced
-*/
-
-const { promisify } = require(&apos;util&apos;);
-const fs = require(&apos;fs&apos;);
-
-const errors = require(&apos;./errors&apos;);
+<div class="content" data-ice="content"><h1 data-ice="title">lib/parsers/orderItems.js</h1>
+<pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">const { forceArray, transformObjectKeys } = require(&apos;../util/transformers&apos;);
 
 /**
- * Promisified version of fs.writeFile
- * We like to use Promises. writeFile does not come in a Promise variant, currently.
- * Use util/promisify to make it work with Promises.
- * This is better than using writeFileSync. Trust me. :-)
- * @param {string} fileName - path/filename to write to
- * @param {string|Buffer} contents - what to write to file
+ * @typedef OrderItem - see https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_Datatypes.html#OrderItem
  */
-const writeFile = promisify(fs.writeFile);
-
-const { callEndpoint } = require(&apos;./callEndpoint&apos;);
-const sleep = require(&apos;./util/sleep&apos;);
 
 /**
- * @typedef ReportRequestInfo
- * @param {string} ReportType Type of Report Requested @see {@link REQUEST_REPORT_TYPES}
- * @param {string} ReportProcessingStatus Status of Report @see {@link REPORT_PROCESSING_STATUS_TYPES}
- * @param {string} EndDate ISO Date for Date Ending period
- * @param {boolean} Scheduled True if report is scheduled, false if immediate
- * @param {string} ReportRequestId Identifier to use with getReport to fetch the report when ready
- * @param {string} SubmittedDate ISO Date for Date request was submitted
- * @param {string} StartDate ISO Date for Date report begins at
+ * @typedef OrderItemsList - a list of OrderItems - see https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_Datatypes.html#OrderItem
  */
-// TODO: convert ISO Dates to Date objects?
 
 /**
- * Request a report from MWS
- * Many optional parameters may be required by MWS! Read [ReportType](https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html) for specifics!
+ * @typedef orderItemsList - the mws-advanced items list
+ * @param {orderItems} - array of OrderItem
+ * @param {nextToken} - string for next token to provide to calls to ListOrderItemsByNextToken
+ * @param {orderId} - string with the Amazon Order ID
+ */
+
+/**
+ * Transform known integer and bool fields from strings to real integer and boolean
  *
- * @async
- * @param {object} options
- * @param {string} options.ReportType Type of Report to Request @see {@link REQUEST_REPORT_TYPES}
- * @param {Date} [options.StartDate] Date to start report
- * @param {Date} [options.EndDate] Date to end report at
- * @param {object} [options.ReportOptions] Reports may have additional options available. Please see the [ReportType](https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html) official docs
- * @param {string[]} [MarketplaceId] Array of marketplace IDs to generate reports covering
- * @returns {ReportRequestInfo}
- */
-const requestReport = async (options) =&gt; {
-    const result = await callEndpoint(&apos;RequestReport&apos;, options);
-    return result.ReportRequestInfo;
-};
-
-// interesting note: there are tons of reports returned by this API,
-// apparently Amazon auto pulls reports, and many reports pulled in the Seller Central
-// interface will also show up here. Somewhere in the docs, it says that Amazon
-// keeps all reports for 90 days.
-
-// TODO: for some reason GetReportRequestListResult showsmentation twice.
-/**
- * @typedef GetReportRequestListResult
- * @param {string} ReportType Type of Report Requested @see {@link REQUEST_REPORT_TYPES}
- * @param {string} ReportProcessingStatus Status of Report @see {@link REPORT_PROCESSING_STATUS_TYPES}
- * @param {string} EndDate ISO Date for Report End Period
- * @param {boolean} Scheduled True if report is scheduled, false if immediate
- * @param {string} ReportRequestId Identifier for the Report Request
- * @param {string} StartedProcessingDate ISO Date for time MWS started processing request
- * @param {string} StartDate ISO Date for Report Start Period
- * @param {string} CompletedDate ISO Date for time MWS completed processing request
- * @param {string} GeneratedReportId Identifier to use with getReport to retrieve the report
+ * @private
+ * @param {OrderItem} item - OrderItem
+ * @returns {OrderItem} - OrderItem with the quantities parseInt()ed, and bools converted from strings
  */
 
+function transformIntsAndBools(item) {
+    const { quantityOrdered, quantityShipped, isGift, productInfo, ...restItem } = item;
+    const { numberOfItems, ...restProductInfo } = productInfo;
+
+    return {
+        ...restItem,
+        isGift: !!(isGift === &apos;true&apos;),
+        quantityOrdered: parseInt(quantityOrdered, 10),
+        quantityShipped: parseInt(quantityShipped, 10),
+        productInfo: {
+            ...restProductInfo,
+            numberOfItems: parseInt(numberOfItems, 10),
+        },
+    };
+}
 /**
- * Returns a list of report requests that you can use to get the ReportRequestId for a report
- * After calling requestReport, you should call this function occasionally to see if/when the report
- * has been processed.
+ * Transform MWS OrderItemsList
  *
- * @async
- * @param {object} [options] Options to pass to GetReportRequestList
- * @param {string[]} [ReportRequestIdList] List of report request IDs @see {@link requestReport}
- * @param {string[]} [ReportTypeList] List of Report Types @see {@link REQUEST_REPORT_TYPES}
- * @param {string[]} [ReportProcessingStatusList] List of Report Processing Status @see {@link REPORT_PROCESSING_STATUS_TYPES}
- * @param {number} [MaxCount=10] Maximum number of report requests to return, max is 100
- * @param {Date} [RequestedFromDate=90-days-past] Oldest date to search for
- * @param {Date} [RequestedToDate=Now] Newest date to search for
- * @returns {GetReportRequestListResult[]}
+ * @private
+ * @param {OrderItemsList} orderItemsList - mws OrderItemsList
+ * @returns {orderItemsList}
  */
-// TODO: make sure we get NextToken out of there and into the main data structure somewhere
-const getReportRequestList = async (options = {}) =&gt; {
-    const result = await callEndpoint(&apos;GetReportRequestList&apos;, options);
-    // NextToken is under result.GetReportRequestListResponse.GetReportRequestListResult
-    return result.ReportRequestInfo;
+const parseOrderItems = (orderItemsList) =&gt; {
+    const { NextToken: nextToken, AmazonOrderId: orderId } = orderItemsList;
+    const arr = forceArray(orderItemsList.OrderItems);
+    const orderItems = arr.map(x =&gt; transformIntsAndBools(transformObjectKeys(x.OrderItem)));
+    const ret = {
+        orderItems,
+        nextToken,
+        orderId,
+    };
+    return ret;
 };
 
-/**
- * Returns the contents of a report
- * @async
- * @param {object} options Options to pass to GetReport
- * @param {string} options.ReportId Report number from @see {@link GetReportList} or GeneratedReportId from @see {@link GetReportRequestListResult}
- * @return {Array|object} Contents of the report to return (format may vary WIDELY between different reports generated, see [ReportType](https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html))
- */
-const getReport = async (options) =&gt; {
-    const result = await callEndpoint(&apos;GetReport&apos;, options);
-    return result;
-};
-
-/**
- * TODO: write documentation for getReportList
- */
-const getReportList = async (options = {}) =&gt; {
-    const result = await callEndpoint(&apos;GetReportList&apos;, options);
-    // NextToken should be in result.GetReportListResponse.GetReportListResult
-    try {
-        const ret = {
-            result: result.ReportInfo,
-            nextToken: result.HasNext &amp;&amp; result.NextToken,
-        };
-        return ret;
-    } catch (err) {
-        return result;
-    }
-};
-
-/**
- * TODO: write documentation for getReportListByNextToken
- * (or just roll getReportList and getReportListByNextToken into the same wrapper)
- * (that wrapper might be getReportListAll, and just rename it)
- */
-const getReportListByNextToken = async (options) =&gt; {
-    const result = await callEndpoint(&apos;GetReportListByNextToken&apos;, options);
-    try {
-        const ret = {
-            result: result.ReportInfo,
-            nextToken: result.HasNext &amp;&amp; result.NextToken,
-        };
-        return ret;
-    } catch (err) {
-        return result;
-    }
-};
-
-/**
- * TODO: write documentation for getReportListAll (or see comment on getReportListByNextToken)
- */
-const getReportListAll = async (options = {}) =&gt; {
-    let reports = [];
-    const reportList = await getReportList(options);
-    reports = reports.concat(reportList.result);
-    let { nextToken } = reportList;
-    /* eslint-disable no-await-in-loop */
-    while (nextToken) {
-        const nextPage = await getReportListByNextToken({ NextToken: nextToken });
-        // eslint-disable-next-line prefer-destructuring
-        nextToken = nextPage.nextToken;
-        reports = reports.concat(nextPage.result);
-        await sleep(2000);
-    }
-    /* eslint-enable no-await-in-loop */
-    return reports;
-};
-
-// TODO: should we emit events notifying of things happening inside here?
-// TODO: need to test all report types with this function, because not all reports return
-// the same set of data - some are not giving a ReportRequestId for some reason?!
-// perhaps there was an error in requestReport() regarding this.
-
-// TODO: _GET_FLAT_FILE_ORDERS_DATA_ seems to always result in a cancelled report
-// TODO: _GET_FLAT_FILE_PENDING_ORDERS_DATA_ results in undefined reportRequestId
-// TODO: undefined reportRequestId results in us downloading a large list of reports
-// when we call getReportRequestList()
-// TODO: need to improve the throttling mechanism, waiting 45 seconds per test minimum sucks.
-
-// known to work if given a StartDate: _GET_FLAT_FILE_ORDERS_DATA_, _GET_AMAZON_FULFILLED_SHIPMENTS_DATA_
-// known to require calling GetReportList (therefore not yet working): _GET_SELLER_FEEDBACK_DATA_
-// _GET_AMAZON_FULFILLED_SHIPMENTS_DATA_
-//
-// unsure why not working: _GET_FLAT_FILE_ACTIONABLE_ORDER_DATA_ - i may not have any data.
-// may require parameters? just cancells if not given parameters.
-//  _GET_CONVERGED_FLAT_FILE_SOLD_LISTINGS_DATA_
-//  _GET_CONVERGED_FLAT_FILE_ORDER_REPORT_DATA_
-//  _GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_
-//  _GET_FLAT_FILE_ALL_RDERS_DATA_BY_ORDER_DATE_
-//  _GET_XML_ALL_ORDERS_DATA_BY_LAST_UPDATE_
-//  _GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_
-//  _GET_FLAT_FILE_PENDING_ORDERS_DATA_ - may also have failed due to not having any pending orders?
-// after I got to _GET_FLAT_FILE_PENDING_ORDERS_DATA_ .. getReportRequestList started throwing out
-// &quot;undefined&quot; as a status. wtf?
-//  _GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_
-//  _GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_
-//  _GET_XML_ALL_ORDERS_DATA_BY_LAST_UPDATE_
-//  _GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_
-
-
-/**
- * TODO: Document requestAndDownloadReport
- */
-const requestAndDownloadReport = async (ReportType, file, reportParams = {}) =&gt; {
-    async function checkReportComplete(reportRequestId) {
-        console.log(`-- checking if report is complete ${reportRequestId}`);
-        /* eslint-disable no-await-in-loop */
-        while (true) {
-            const report = await getReportRequestList({
-                ReportRequestIdList: [reportRequestId],
-            });
-            switch (report.ReportProcessingStatus) {
-                case &apos;_IN_PROGRESS_&apos;: // fallthrough intentional
-                case &apos;_SUBMITTED_&apos;: // fallthrough intentional
-                    console.log(`-- retrying report ${reportRequestId} in 45 sec`);
-                    await sleep(45000); // GetReportRequestList throttles to at most 10 requests, you get 1 back every 45 seconds
-                    break;
-                case &apos;_CANCELLED_&apos;:
-                    console.log(`-- cancelled: ${reportRequestId}`, report);
-                    return { cancelled: true };
-                case &apos;_DONE_&apos;:
-                    return report;
-                case &apos;_DONE_NO_DATA_&apos;:
-                    return null;
-                default:
-                    console.log(`-- unknown status retry in 45 sec: ${report.ReportProcessingStatus}`, report);
-                    await sleep(45000);
-                    break;
-            }
-        }
-        /* eslint-enable no-await-in-loop */
-    }
-
-    console.log(`-- requesting report ${ReportType}`);
-    const request = await requestReport({
-        ReportType,
-        ...reportParams,
-    });
-    const reportRequestId = request.ReportRequestId;
-    await sleep(20000); // some requests may be available quickly, check after 20 sec
-    const reportCheck = await checkReportComplete(reportRequestId);
-    if (reportCheck.cancelled) {
-        console.warn(&apos;******** report request cancelled by server&apos;, ReportType);
-        throw new errors.RequestCancelled(&apos;Report cancelled by server&apos;);
-    }
-    let ReportId = reportCheck.GeneratedReportId;
-
-    // When no ReportId is received, then call getReportList to find it.
-    if (!ReportId) {
-        const reportList = await getReportList({
-            ReportTypeList: [ReportType],
-        });
-
-        ReportId = reportList[reportList.length - 1].ReportId;
-    }
-    const report = await getReport({ ReportId });
-    if (file) {
-        await writeFile(file, JSON.stringify(report, null, 4));
-    }
-    return report;
-};
-
-module.exports = {
-    getReport,
-    getReportList,
-    getReportListAll,
-    getReportListByNextToken,
-    getReportRequestList,
-    requestAndDownloadReport,
-    requestReport,
-};
+module.exports = parseOrderItems;
 </code></pre>
 
 </div>

--- a/docs/file/lib/util/sleep.js.html
+++ b/docs/file/lib/util/sleep.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/file/lib/validation.js.html
+++ b/docs/file/lib/validation.js.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/docs/function/index.html
+++ b/docs/function/index.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -2448,11 +2451,11 @@ const mws = MWS.init({ host: &apos;alternate-mws-server.com&apos;, accessKeyId, 
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/list-order-items.js.html#lineNumber42">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/list-order-items.js.html#lineNumber41">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {listOrderItems} from &apos;<span><a href="file/lib/list-order-items.js.html#lineNumber42">mws-advanced/lib/list-order-items.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import {listOrderItems} from &apos;<span><a href="file/lib/list-order-items.js.html#lineNumber41">mws-advanced/lib/list-order-items.js</a></span>&apos;</code></pre></div>
   
   
   <div data-ice="description"><p>Returns order items based on the AmazonOrderId that you specify.</p>
@@ -2774,11 +2777,11 @@ If you are having trouble, see the official parameter documentation above.</p>
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/parsers/feesEstimate.js.html#lineNumber3">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/parsers/feesEstimate.js.html#lineNumber28">source</a></span></span>
     </span>
   </h3>
 
-  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import parseFeesEstimate from &apos;<span><a href="file/lib/parsers/feesEstimate.js.html#lineNumber3">mws-advanced/lib/parsers/feesEstimate.js</a></span>&apos;</code></pre></div>
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode">import parseFeesEstimate from &apos;<span><a href="file/lib/parsers/feesEstimate.js.html#lineNumber28">mws-advanced/lib/parsers/feesEstimate.js</a></span>&apos;</code></pre></div>
   
   
   

--- a/docs/identifiers.html
+++ b/docs/identifiers.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -1720,6 +1723,90 @@ Many optional parameters may be required by MWS! Read <a href="https://docs.deve
           
           
           <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span><span class="code" data-ice="signature">(type: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, id: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>): <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-typedef">T</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span><span class="code" data-ice="signature">: <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-typedef">T</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span><span class="code" data-ice="signature">: <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-typedef">T</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span><span class="code" data-ice="signature">(-: <span>orderItems</span>, -: <span>nextToken</span>, -: <span>orderId</span>): <span>*</span></span>
         </p>
       </div>
       <div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,8 @@ mws.init({
         MarketplaceId: [ &apos;ATVDPKIKX0DER&apos; ],
     });
     console.log(`Orders: ${JSON.stringify(orders, null, 4)}`);
-})();</code>
+})();
+</code>
 </code></pre><h1 id="example-usage---multiple-instance-capability">Example usage - Multiple instance capability</h1><pre><code><code class="source-code prettyprint">const MWS = require(&apos;mws-advanced).MWSAdvanced;
 
 (async function() {

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -90,7 +90,8 @@ mws.init({
         MarketplaceId: [ &apos;ATVDPKIKX0DER&apos; ],
     });
     console.log(`Orders: ${JSON.stringify(orders, null, 4)}`);
-})();</code>
+})();
+</code>
 </code></pre><h1 id="example-usage---multiple-instance-capability">Example usage - Multiple instance capability</h1><pre><code><code class="source-code prettyprint">const MWS = require(&apos;mws-advanced).MWSAdvanced;
 
 (async function() {

--- a/docs/script/search_index.js
+++ b/docs/script/search_index.js
@@ -828,6 +828,30 @@ window.esdocSearchIndex = [
     "typedef"
   ],
   [
+    "lib/parsers/orderitems.js",
+    "file/lib/parsers/orderItems.js.html",
+    "lib/parsers/orderItems.js",
+    "file"
+  ],
+  [
+    "lib/parsers/orderitems.js~orderitem",
+    "typedef/index.html#static-typedef-OrderItem",
+    "lib/parsers/orderItems.js~OrderItem",
+    "typedef"
+  ],
+  [
+    "lib/parsers/orderitems.js~orderitemslist",
+    "typedef/index.html#static-typedef-OrderItemsList",
+    "lib/parsers/orderItems.js~OrderItemsList",
+    "typedef"
+  ],
+  [
+    "lib/parsers/orderitems.js~orderitemslist",
+    "typedef/index.html#static-typedef-orderItemsList",
+    "lib/parsers/orderItems.js~orderItemsList",
+    "typedef"
+  ],
+  [
     "lib/reports.js",
     "file/lib/reports.js.html",
     "lib/reports.js",

--- a/docs/source.html
+++ b/docs/source.html
@@ -85,11 +85,14 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">67/125</span></h1>
+<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">69/133</span></h1>
 
 <table class="files-summary" data-ice="files" data-use-coverage="true">
   <thead>
@@ -144,9 +147,9 @@
       <td data-ice="filePath"><span><a href="file/lib/endpoints/endpoints-utils.js.html">lib/endpoints/endpoints-utils.js</a></span></td>
       <td data-ice="identifier" class="identifiers">-</td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
-      <td style="display: none;" data-ice="size">1388 byte</td>
+      <td style="display: none;" data-ice="size">1229 byte</td>
       <td style="display: none;" data-ice="lines">35</td>
-      <td style="display: none;" data-ice="updated">2018-02-01 23:47:50 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2018-05-03 08:44:57 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/endpoints/feeds.js.html#errorLines=10,11,13,15">lib/endpoints/feeds.js</a></span></td>
@@ -334,9 +337,9 @@
       <td data-ice="filePath"><span><a href="file/lib/list-order-items.js.html">lib/list-order-items.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-listOrderItems">listOrderItems</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">1/1</span></td>
-      <td style="display: none;" data-ice="size">2197 byte</td>
-      <td style="display: none;" data-ice="lines">56</td>
-      <td style="display: none;" data-ice="updated">2018-02-01 23:47:50 (UTC)</td>
+      <td style="display: none;" data-ice="size">1910 byte</td>
+      <td style="display: none;" data-ice="lines">48</td>
+      <td style="display: none;" data-ice="updated">2018-05-07 01:36:09 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/list-orders.js.html">lib/list-orders.js</a></span></td>
@@ -347,20 +350,20 @@
       <td style="display: none;" data-ice="updated">2018-02-01 23:47:50 (UTC)</td>
     </tr>
 <tr data-ice="file">
-      <td data-ice="filePath"><span><a href="file/lib/parsers/feesEstimate.js.html#errorLines=3">lib/parsers/feesEstimate.js</a></span></td>
+      <td data-ice="filePath"><span><a href="file/lib/parsers/feesEstimate.js.html#errorLines=11,15,19,23,28,3,7">lib/parsers/feesEstimate.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="function/index.html#static-function-parseFeesEstimate">parseFeesEstimate</a></span></td>
-      <td class="coverage"><span data-ice="coverage">0 %</span><span data-ice="coverageCount" class="coverage-count">0/1</span></td>
-      <td style="display: none;" data-ice="size">1020 byte</td>
-      <td style="display: none;" data-ice="lines">24</td>
-      <td style="display: none;" data-ice="updated">2018-05-03 06:58:56 (UTC)</td>
+      <td class="coverage"><span data-ice="coverage">0 %</span><span data-ice="coverageCount" class="coverage-count">0/7</span></td>
+      <td style="display: none;" data-ice="size">1516 byte</td>
+      <td style="display: none;" data-ice="lines">50</td>
+      <td style="display: none;" data-ice="updated">2018-05-03 09:02:18 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/parsers/lowestPricedOffers.js.html">lib/parsers/lowestPricedOffers.js</a></span></td>
       <td data-ice="identifier" class="identifiers">-</td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">6220 byte</td>
-      <td style="display: none;" data-ice="lines">195</td>
-      <td style="display: none;" data-ice="updated">2018-05-01 15:46:45 (UTC)</td>
+      <td style="display: none;" data-ice="size">6224 byte</td>
+      <td style="display: none;" data-ice="lines">196</td>
+      <td style="display: none;" data-ice="updated">2018-05-03 09:08:25 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/parsers/marketplaceData.js.html">lib/parsers/marketplaceData.js</a></span></td>
@@ -377,6 +380,14 @@
       <td style="display: none;" data-ice="size">2171 byte</td>
       <td style="display: none;" data-ice="lines">61</td>
       <td style="display: none;" data-ice="updated">2018-05-02 06:33:53 (UTC)</td>
+    </tr>
+<tr data-ice="file">
+      <td data-ice="filePath"><span><a href="file/lib/parsers/orderItems.js.html">lib/parsers/orderItems.js</a></span></td>
+      <td data-ice="identifier" class="identifiers">-</td>
+      <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
+      <td style="display: none;" data-ice="size">2007 byte</td>
+      <td style="display: none;" data-ice="lines">60</td>
+      <td style="display: none;" data-ice="updated">2018-05-07 02:03:11 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/lib/reports.js.html">lib/reports.js</a></span></td>

--- a/docs/typedef/index.html
+++ b/docs/typedef/index.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -528,7 +531,63 @@
           
           
           
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span><span class="code" data-ice="signature">: <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
           <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemList">OrderItemList</a></span></span><span class="code" data-ice="signature">(orderId: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, nextToken: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>, orderItems: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></span>): <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span><span class="code" data-ice="signature">: <span>*</span></span>
         </p>
       </div>
       <div>
@@ -641,6 +700,34 @@
           
           
           <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span><span class="code" data-ice="signature">(unknown: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></span>): <span>*</span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span><span class="code" data-ice="signature">(-: <span>orderItems</span>, -: <span>nextToken</span>, -: <span>orderId</span>): <span>*</span></span>
         </p>
       </div>
       <div>
@@ -1114,7 +1201,7 @@
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/lib/parsers/lowestPricedOffers.js.html#lineNumber180">source</a></span></span>
+      <span data-ice="source"><span><a href="file/lib/parsers/lowestPricedOffers.js.html#lineNumber181">source</a></span></span>
     </span>
   </h3>
 
@@ -1361,6 +1448,49 @@
   
 </div>
 <div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-typedef-OrderItem">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">OrderItem</span><span class="code" data-ice="signature">: <span>*</span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/lib/parsers/orderItems.js.html#lineNumberundefined">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  
+
+  
+
+  <div data-ice="properties">
+</div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
   <h3 data-ice="anchor" id="static-typedef-OrderItemList">
     <span class="access" data-ice="access">public</span>
     
@@ -1373,6 +1503,49 @@
       
       
       <span data-ice="source"><span><a href="file/lib/list-order-items.js.html#lineNumberundefined">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  
+
+  
+
+  <div data-ice="properties">
+</div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-typedef-OrderItemsList">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">OrderItemsList</span><span class="code" data-ice="signature">: <span>*</span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/lib/parsers/orderItems.js.html#lineNumberundefined">source</a></span></span>
     </span>
   </h3>
 
@@ -1545,6 +1718,49 @@
       
       
       <span data-ice="source"><span><a href="file/lib/parsers/lowestPricedOffers.js.html#lineNumberundefined">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  
+
+  
+
+  <div data-ice="properties">
+</div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-typedef-orderItemsList">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">orderItemsList</span><span class="code" data-ice="signature">(-: <span>orderItems</span>, -: <span>nextToken</span>, -: <span>orderId</span>): <span>*</span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/lib/parsers/orderItems.js.html#lineNumberundefined">source</a></span></span>
     </span>
   </h3>
 

--- a/docs/variable/index.html
+++ b/docs/variable/index.html
@@ -85,6 +85,9 @@
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-SellerFeedbackRating">SellerFeedbackRating</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ShipsFrom">ShipsFrom</a></span></span></li>
 <li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-ProductIdentifier">ProductIdentifier</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItem">OrderItem</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-OrderItemsList">OrderItemsList</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-typedef">T</span><span data-ice="name"><span><a href="typedef/index.html#static-typedef-orderItemsList">orderItemsList</a></span></span></li>
 </ul>
 </div>
 </nav>

--- a/lib/list-order-items.js
+++ b/lib/list-order-items.js
@@ -1,9 +1,8 @@
 /**
  * @module mws-advanced
  */
-const { callEndpoint } = require('./callEndpoint');
-const { digResponseResult } = require('./dig-response-result');
-const { forceArray } = require('./util/transformers');
+const { parseEndpoint } = require('./callEndpoint');
+const parseOrderItems = require('./parsers/orderItems');
 
 // TODO: make a typedef for OrderItem and document it correctly
 /**
@@ -40,15 +39,8 @@ const { forceArray } = require('./util/transformers');
  * @returns {OrderItemList}
  */
 const listOrderItems = async (AmazonOrderId) => {
-    const res = digResponseResult('ListOrderItems', await callEndpoint('ListOrderItems', { AmazonOrderId }));
-    const arr = forceArray(res.OrderItems);
-    const meh = arr.map(x => x.OrderItem);
-    const ret = {
-        nextToken: res.nextToken,
-        orderId: res.AmazonOrderId,
-        orderItems: meh,
-    };
-    return ret;
+    const results = await parseEndpoint('ListOrderItems', { AmazonOrderId })(parseOrderItems);
+    return results;
 };
 
 module.exports = {

--- a/lib/parsers/orderItems.js
+++ b/lib/parsers/orderItems.js
@@ -1,0 +1,66 @@
+const { forceArray, transformObjectKeys } = require('../util/transformers');
+
+/**
+ * @typedef OrderItem - see https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_Datatypes.html#OrderItem
+ */
+
+/**
+ * @typedef OrderItemsList - a list of OrderItems - see https://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_Datatypes.html#OrderItem
+ */
+
+/**
+ * @typedef orderItemsList - the mws-advanced items list
+ * @param {orderItems} - array of OrderItem
+ * @param {nextToken} - string for next token to provide to calls to ListOrderItemsByNextToken
+ * @param {orderId} - string with the Amazon Order ID
+ */
+
+/**
+ * Transform known integer and bool fields from strings to real integer and boolean
+ *
+ * @private
+ * @param {OrderItem} item - OrderItem
+ * @returns {OrderItem} - OrderItem with the quantities parseInt()ed, and bools converted from strings
+ */
+
+function transformIntsAndBools(item) {
+    const {
+        quantityOrdered,
+        quantityShipped,
+        isGift,
+        productInfo,
+        ...restItem
+    } = item;
+    const { numberOfItems, ...restProductInfo } = productInfo;
+
+    return {
+        ...restItem,
+        isGift: !!(isGift === 'true'),
+        quantityOrdered: parseInt(quantityOrdered, 10),
+        quantityShipped: parseInt(quantityShipped, 10),
+        productInfo: {
+            ...restProductInfo,
+            numberOfItems: parseInt(numberOfItems, 10),
+        },
+    };
+}
+/**
+ * Transform MWS OrderItemsList
+ *
+ * @private
+ * @param {OrderItemsList} orderItemsList - mws OrderItemsList
+ * @returns {orderItemsList}
+ */
+const parseOrderItems = (orderItemsList) => {
+    const { NextToken: nextToken, AmazonOrderId: orderId } = orderItemsList;
+    const arr = forceArray(orderItemsList.OrderItems);
+    const orderItems = arr.map(x => transformIntsAndBools(transformObjectKeys(x.OrderItem)));
+    const ret = {
+        orderItems,
+        nextToken,
+        orderId,
+    };
+    return ret;
+};
+
+module.exports = parseOrderItems;

--- a/test/mock/ListOrderItems.json
+++ b/test/mock/ListOrderItems.json
@@ -1,0 +1,1 @@
+{"OrderItems":{"OrderItem":{"QuantityOrdered":"0","Title":"Midnight in the Garden of Good and Evil: A Savannah Story [Paperback] [1999] Berendt, John","IsGift":"false","ASIN":"0679751521","SellerSKU":"Y3-8ZR6-ZZ9O","OrderItemId":"25379512800154","ProductInfo":{"NumberOfItems":"1"},"QuantityShipped":"0"}},"AmazonOrderId":"112-1275545-4224234"}

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -51,10 +51,9 @@ describe('Misc Utils', () => {
         expect(result[0]).to.deep.equal({ test: 1, test2: 2 });
         done();
     });
-    it('flattenResult returns object when given object', (done) => {
+    it('flattenResult returns object when given object', () => {
         const result = flattenResult({ test: 1, test2: 2 });
-        expect(result).to.deep.equal({ test: 1, test2: 2 });
-        done();
+        return expect(result).to.deep.equal({ test: 1, test2: 2 });
     });
     it('flattenResult() returns flat results', (done) => {
         const result = flattenResult({
@@ -84,15 +83,16 @@ describe('Misc Utils', () => {
 
         done();
     });
-    it('digResponseResult() returns nameResponse.nameResult', (done) => {
+    it('digResponseResult() returns nameResponse.nameResult', () => {
         const result = digResponseResult('ListMarketplaceParticipations', listMarketplacesData);
-        expect(result).to.be.an('object');
-        expect(result).to.have.keys('ListParticipations', 'ListMarketplaces');
-        done();
+        return expect(result).to.be.an('object').that.has.keys('ListParticipations', 'ListMarketplaces');
     });
-    it('digResponseResult() throws ServiceError on error message (simulated from server)', (done) => {
-        expect(() => digResponseResult('ListMarketplaceParticipations', errorData)).to.throw(errors.ServiceError);
-        done();
+    it('digResponseResult() throws ServiceError on error message (simulated from server)', () => {
+        return expect(() => digResponseResult('ListMarketplaceParticipations', errorData)).to.throw(errors.ServiceError);
+    });
+    it('digResponseResult() returns original input if there is no {name}Response field or ErrorResponse', () => {
+        const result = digResponseResult('test', { xyz: 1 });
+        return expect(result).to.deep.equal({ xyz: 1 });
     });
 });
 
@@ -165,11 +165,10 @@ describe('transformers', () => {
                 },
             };
             const x = transformers.objToValueSub(test);
-            expect(x).to.deep.equal({
+            return expect(x).to.deep.equal({
                 value: '0.20',
                 units: 'inches',
             });
-            return true;
         });
     });
     describe('transformKey', () => {
@@ -179,25 +178,24 @@ describe('transformers', () => {
             return true;
         });
         it('returns input when given probable acronym (UPPERCASE)', () => {
-            expect(transformers.transformKey('UPPERCASE')).to.equal('UPPERCASE');
-            return true;
+            return expect(transformers.transformKey('UPPERCASE')).to.equal('UPPERCASE');
         });
     });
     describe('removeFromString', () => {
         it('returns a string minus a substring', () => {
-            expect(transformers.removeFromString('testString', 'String')).to.equal('test');
+            return expect(transformers.removeFromString('testString', 'String')).to.equal('test');
         });
         it('returns a string minus a regex pattern', () => {
-            expect(transformers.removeFromString('testString', /^test/)).to.equal('String');
+            return expect(transformers.removeFromString('testString', /^test/)).to.equal('String');
         });
     });
     describe('transformAttributeSetKey', () => {
         it('extends transformKey to remove "ns2:" from beginning of key, ns2:ItemAttributes=>itemAttributes', () => {
-            expect(transformers.transformAttributeSetKey('ns2:ItemAttributes')).to.equal('itemAttributes');
+            return expect(transformers.transformAttributeSetKey('ns2:ItemAttributes')).to.equal('itemAttributes');
         });
     });
     describe('transformObjectKeys', () => {
-        it('simple test with getMarketplaces data', () => {
+        it('simple test with getMarketplaces data', (done) => {
             const testData = require('./data/transformObjectKeys-1.json');
             /* eslint-disable dot-notation */
             const res = transformers.transformObjectKeys(testData)['ATVPDKIKX0DER'];
@@ -211,13 +209,15 @@ describe('transformers', () => {
             expect(comp.DefaultLanguageCode).to.equal(res.defaultLanguageCode);
             expect(comp.SellerId).to.equal(res.sellerId);
             expect(comp.HasSellerSuspendedListings).to.equal(res.hasSellerSuspendedListings);
+            done();
         });
-        it('extended test with getMatchingProductForId attribute data, using transformAttributeSetKey, test ns2:MaterialType => materialType', () => {
+        it('extended test with getMatchingProductForId attribute data, using transformAttributeSetKey, test ns2:MaterialType => materialType', (done) => {
             const testData = require('./data/transformObjectKeys-2.json');
             const res = transformers.transformObjectKeys(testData, transformers.transformAttributeSetKey);
             testData.forEach((x, i) => {
                 expect(x.AttributeSets['ns2:ItemAttributes']['ns2:MaterialType']).to.deep.equal(res[i].attributeSets.itemAttributes.materialType);
             });
+            done();
         });
         // TODO: write detailed tests for transformObjectKeys.
         // TODO: should grab actual data from the base API and compare it.
@@ -225,10 +225,7 @@ describe('transformers', () => {
 });
 
 describe('isType', () => {
-    it('unknown type passes as always valid', (done) => {
-        expect(isType('testtype', 'junkdata')).to.be.true;
-        done();
-    });
+    it('unknown type passes as always valid', () => expect(isType('testtype', 'junkdata')).to.be.true);
     it('xs:int', (done) => {
         expect(isType('xs:int', 0)).to.be.true;
         expect(isType('xs:int', 1)).to.be.true;
@@ -270,15 +267,13 @@ describe('isType', () => {
         expect(() => isType('xs:nonNegativeInteger', 1000, range)).to.throw(errors.ValidationError);
         done();
     });
-    it('xs:string accepts regular strings', (done) => {
+    it('xs:string accepts regular strings', () => {
         const valid = isType('xs:string', 'this is a regular string');
-        expect(valid).to.be.true;
-        done();
+        return expect(valid).to.be.true;
     });
-    it('xs:string accepts string objects', (done) => {
+    it('xs:string accepts string objects', () => {
         const valid = isType('xs:string', String('this is a string object'));
-        expect(valid).to.be.true;
-        done();
+        return expect(valid).to.be.true;
     });
     it('xs:string does not accept things that are definitely not strings', (done) => {
         expect(isType('xs:string', { test: true })).to.be.false;
@@ -286,13 +281,11 @@ describe('isType', () => {
         expect(isType('xs:string', new Date())).to.be.false;
         done();
     });
-    it('xs:dateTime fails Date objects (validateAndTransform converts them to ISO)', (done) => {
-        expect(isType('xs:dateTime', new Date())).to.be.false;
-        done();
+    it('xs:dateTime fails Date objects (validateAndTransform converts them to ISO)', () => {
+        return expect(isType('xs:dateTime', new Date())).to.be.false;
     });
-    it('xs:dateTime accepts ISO Strings', (done) => {
-        expect(isType('xs:dateTime', new Date().toISOString())).to.be.true;
-        done();
+    it('xs:dateTime accepts ISO Strings', () => {
+        return expect(isType('xs:dateTime', new Date().toISOString())).to.be.true;
     });
     it('xs:dateTime fails non-ISO strings', (done) => {
         expect(() => isType('xs:dateTime', 'string')).to.throw(RangeError); // Date constructor throws
@@ -323,27 +316,12 @@ describe('validateAndTransformParameters', () => {
             required: false,
         },
     };
-    it('called with undefined first arg returns without parsing', (done) => {
-        expect(validateAndTransformParameters(undefined, 123)).to.equal(123);
-        done();
-    });
-    it('unknown parameter throws', (done) => {
-        expect(() => validateAndTransformParameters(req, { BadTest: 'test' })).to.throw();
-        done();
-    });
-    it('incorrect type throws', (done) => {
-        expect(() => validateAndTransformParameters(req, { ReqTest: 123 })).to.throw();
-        done();
-    });
+    it('called with undefined first arg returns without parsing', () => expect(validateAndTransformParameters(undefined, 123)).to.equal(123));
+    it('unknown parameter throws', () => expect(() => validateAndTransformParameters(req, { BadTest: 'test' })).to.throw());
+    it('incorrect type throws', () => expect(() => validateAndTransformParameters(req, { ReqTest: 123 })).to.throw());
     describe('required parameters', () => {
-        it('required parameter present works', (done) => {
-            expect(validateAndTransformParameters(req, { ReqTest: 'test' })).to.deep.equal({ ReqTest: 'test' });
-            done();
-        });
-        it('required parameter not present throws', (done) => {
-            expect(() => validateAndTransformParameters(req, { NotReqTest: 'test' })).to.throw(errors.ValidationError);
-            done();
-        });
+        it('required parameter present works', () => expect(validateAndTransformParameters(req, { ReqTest: 'test' })).to.deep.equal({ ReqTest: 'test' }));
+        it('required parameter not present throws', () => expect(() => validateAndTransformParameters(req, { NotReqTest: 'test' })).to.throw(errors.ValidationError));
     });
     describe('Array to List transformation', () => {
         const listTest = {
@@ -354,28 +332,15 @@ describe('validateAndTransformParameters', () => {
                 listMax: 2,
             },
         };
-        it('throws on non-Arrays', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: 'oops' })).to.throw(errors.ValidationError);
-            done();
-        });
-        it('throws on incorrect list data types', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: [123] })).to.throw(errors.ValidationError);
-            done();
-        });
-        it('throws on partial incorrect list data types', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: ['a', 1] })).to.throw(errors.ValidationError);
-            done();
-        });
-        it('throws on exceeding listMax items', (done) => {
-            expect(() => validateAndTransformParameters(listTest, { ListTest: ['1', '2', '3'] })).to.throw(errors.ValidationError);
-            done();
-        });
-        it('outputs correct list parameters (ListTest[x] => Test.List.x+1)', (done) => {
-            expect(validateAndTransformParameters(listTest, { ListTest: ['1', '2'] })).to.deep.equal({
+        it('throws on non-Arrays', () => expect(() => validateAndTransformParameters(listTest, { ListTest: 'oops' })).to.throw(errors.ValidationError));
+        it('throws on incorrect list data types', () => expect(() => validateAndTransformParameters(listTest, { ListTest: [123] })).to.throw(errors.ValidationError));
+        it('throws on partial incorrect list data types', () => expect(() => validateAndTransformParameters(listTest, { ListTest: ['a', 1] })).to.throw(errors.ValidationError));
+        it('throws on exceeding listMax items', () => expect(() => validateAndTransformParameters(listTest, { ListTest: ['1', '2', '3'] })).to.throw(errors.ValidationError));
+        it('outputs correct list parameters (ListTest[x] => Test.List.x+1)', () => {
+            return expect(validateAndTransformParameters(listTest, { ListTest: ['1', '2'] })).to.deep.equal({
                 'Test.List.1': '1',
                 'Test.List.2': '2',
             });
-            done();
         });
     });
 });
@@ -657,6 +622,30 @@ describe('mws-advanced sanity', () => {
 });
 
 describe('Parsers', function runParserTests() {
+    it('listOrderItems parser', function testListOrderItemsParser() {
+        const json = JSON.parse(fs.readFileSync('./test/mock/ListOrderItems.json'));
+        const parser = require('../lib/parsers/orderItems');
+        const results = parser(json);
+        expect(results).to.be.an('Object').and.to.include.all.keys(
+            'orderId',
+            'orderItems',
+        );
+        expect(results.orderId).to.equal('112-1275545-4224234');
+        expect(results.orderItems).to.be.an('Array');
+        const orderItem = results.orderItems[0];
+        expect(orderItem).to.deep.equal({
+            title: 'Midnight in the Garden of Good and Evil: A Savannah Story [Paperback] [1999] Berendt, John',
+            ASIN: '0679751521',
+            sellerSKU: 'Y3-8ZR6-ZZ9O',
+            orderItemId: '25379512800154',
+            productInfo: {
+                numberOfItems: 1,
+            },
+            isGift: false,
+            quantityOrdered: 0,
+            quantityShipped: 0,
+        });
+    });
     it('getMarketplaces parser', function testGetMarketplacesParser() {
         const json = JSON.parse(fs.readFileSync('./test/mock/ListMarketplaceParticipations.json'));
         const parser = require('../lib/parsers/marketplaceData');
@@ -898,7 +887,7 @@ describe('Parsers', function runParserTests() {
     });
 });
 
-describe('API', function runAPITests() {
+describe.only('API', function runAPITests() {
     let marketIds = [];
     let testMarketId = '';
     let orderIds = [];
@@ -958,11 +947,10 @@ describe('API', function runAPITests() {
                     return false;
                 }
                 const results = await mws.listOrderItems(orderId);
-                expect(results).to.be.an('Object').and.to.include.all.keys(
+                return expect(results).to.be.an('Object').and.to.include.all.keys(
                     'orderId',
                     'orderItems',
                 );
-                return true;
             });
             // TODO: we need to get a wrap on GetOrder!
             it('endpoint GetOrder', async function testGetOrder() {


### PR DESCRIPTION
- well, ok, not super big. Mostly the case of the returned values has
  been fixed to match camelCase as the newer functions to be implemented
  uses. But it will definitely break your existing code if you plug this
  in without the minor change to accommodate. Additionally, string values
  that look like ints become ints, and values that look like bools become
  bools.
- again, another warning that i'm not making official version bumps until
  after the majority of the functionality is implemented, i don't want to
  have the first official release be v12.25. :-D  maybe i should consider
  it, though.  Change my mind, eh?
- ok, so here's what's new:
- Separated parsing for listOrderItems into a separate function, and
  implemented it's tests and mock data.
- The new version of the parser function maps all the keys to camelCase,
  probably fixes what appeared to be a broken mapping for NextToken
  (i do not have any 100+ item orders to test, and have not yet tested
  putting a limit on number of items returned, to see if that will allow
  us to test ByNextToken responses with fewer than 100 initial entries)
- Great cleanup for a function that hasn't been revisited since it was
  initially written in one of the earliest releases.