### PR TITLE
new constants.MARKET_CURRENCY

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,7 @@
 
 /**
  * A list of Marketplace IDs hashed by their country code.
+ * @constant
  */
 const MWS_MARKETPLACES = {
     CA: 'A2EUQ1WTGCTBG2',
@@ -24,7 +25,24 @@ const MWS_MARKETPLACES = {
 };
 
 /**
+ * A list of the default currency codes for markets, indexed by country code.
+ * Calling, for example, getMyFeesEstimate in Canada, using USD will fail with
+ * "status":"ClientError",
+ * "error":{
+ *     "code":"InvalidParameterValue",
+ *     "message":"There is an client-side error. Please verify your inputs."
+ * }
+ * so you need to use CAD when calling getMyFeesEstimate for Canada.
+ * @constant
+ */
+const MARKET_CURRENCY = {
+    US: 'USD',
+    CA: 'CAD',
+};
+
+/**
  * A list of hosts you can use with the mws-advanced "host" option, hashed by MWS Region Name.
+ * @constant
  */
 const MWS_ENDPOINTS = {
     NA: 'mws.amazonservices.com',
@@ -39,4 +57,5 @@ const MWS_ENDPOINTS = {
 module.exports = {
     MWS_MARKETPLACES,
     MWS_ENDPOINTS,
+    MARKET_CURRENCY,
 };

--- a/test/test-sanity.js
+++ b/test/test-sanity.js
@@ -480,6 +480,9 @@ describe('mws-advanced sanity', () => {
             );
             done();
         });
+        it('calling MWSAdvanced() without new returns a new object anyway', () => {
+            return expect(mws.MWSAdvanced(initTestParams)).to.be.an('object'); // eslint-disable-line
+        });
         it('init() works when called on a MWSAdvanced instance', (done) => {
             const client = new mws.MWSAdvanced();
             const x = client.init(initTestParams);


### PR DESCRIPTION
- use when you need the default currency for a marketplace, such as when
  constructing getMyFeesEstimate requests
- also add trivial test for calling MWSAdvanced() without new