### PR TITLE
breaking change to getReportRequestList, update most things to use parseEndpoint2

### DIFF
--- a/lib/callEndpoint.js
+++ b/lib/callEndpoint.js
@@ -214,8 +214,8 @@ const parseEndpoint = (name, callOptions, opt) => async (parser) => {
 };
 
 // experimental
-const parseEndpoint2 = parser => name => async (callOptions, opt) =>
-    parser(await callEndpoint(name, callOptions, opt));
+const parseEndpoint2 = (outParser, inParser = x => x) => name => async (callOptions, opt) =>
+    outParser(await callEndpoint(name, inParser(callOptions), opt));
 
 module.exports = {
     init,

--- a/lib/get-matching-product.js
+++ b/lib/get-matching-product.js
@@ -1,7 +1,20 @@
-const { callEndpoint } = require('./callEndpoint');
+const { parseEndpoint2 } = require('./callEndpoint');
 const errors = require('./errors');
 
 const parseMatchingProduct = require('./parsers/matchingProduct');
+
+const inputParser = opt => ({
+    MarketplaceId: opt.marketplaceId || opt.MarketplaceId,
+    IdType: opt.idType || opt.IdType,
+    IdList: opt.idList || opt.IdList,
+});
+
+const outputParser = (out) => {
+    if (out.Error) {
+        throw new errors.ServiceError(out.Error.Message);
+    }
+    return parseMatchingProduct(out);
+};
 
 /**
  * Returns a list of products and their attributes, based on a list of ASIN, GCID, SellerSKU, UPC,
@@ -14,13 +27,8 @@ const parseMatchingProduct = require('./parsers/matchingProduct');
  * @public
  * @returns {Product[]}
  */
-const getMatchingProductForId = async (options) => {
-    const result = await callEndpoint('GetMatchingProductForId', options);
-    if (result.Error) {
-        throw new errors.ServiceError(result.Error.Message);
-    }
-    return parseMatchingProduct(result);
-};
+const getMatchingProductForId =
+    parseEndpoint2(outputParser, inputParser)('GetMatchingProductForId');
 
 module.exports = {
     getMatchingProductForId,

--- a/lib/get-my-fees-estimate.js
+++ b/lib/get-my-fees-estimate.js
@@ -45,14 +45,8 @@ const { forceArray } = require('./util/transformers');
  * @param {Error} [error] - If an Error occurred (success === "Failure"), a description of the Error
  */
 
-/**
- * Get an estimate of fees for an item, based on listing and shipping prices.
- *
- * @param {EstimateRequest[]} - Array of EstimateRequest items to get fees for
- * @returns {Object} - Object of Estimate items, indexed by EstimateRequest Identifier
- */
-const getMyFeesEstimate = async (estimates, callOpt) => {
-    const query = forceArray(estimates).reduce((acc, e, index) => {
+const estimateRequestParser = estimates => (
+    forceArray(estimates).reduce((acc, e, index) => {
         const key = `FeesEstimateRequestList.FeesEstimateRequest.${index + 1}`;
         acc[`${key}.MarketplaceId`] = e.marketplaceId; // TODO: should there be a default marketplaceId ?!
         acc[`${key}.IdType`] = e.idType;
@@ -65,11 +59,16 @@ const getMyFeesEstimate = async (estimates, callOpt) => {
         acc[`${key}.PriceToEstimateFees.Shipping.Amount`] = e.shipping.amount;
         acc[`${key}.Points.PointsNumber`] = e.points ? e.points.pointsNumber : 0;
         return acc;
-    }, {});
+    }, {})
+);
 
-    const res = await parseEndpoint2(parseFeesEstimate)('GetMyFeesEstimate')(query, callOpt);
-    return res;
-};
+/**
+ * Get an estimate of fees for an item, based on listing and shipping prices.
+ *
+ * @param {EstimateRequest[]} - Array of EstimateRequest items to get fees for
+ * @returns {Object} - Object of Estimate items, indexed by EstimateRequest Identifier
+ */
+const getMyFeesEstimate = parseEndpoint2(parseFeesEstimate, estimateRequestParser)('GetMyFeesEstimate');
 
 module.exports = {
     getMyFeesEstimate,

--- a/lib/get-product-categories.js
+++ b/lib/get-product-categories.js
@@ -31,7 +31,7 @@ const getProductCategoriesForSku = ({ marketplaceId, sellerSku }) =>
     }).then(res => ({ sku: sellerSku, ...res })).catch(error => Promise.resolve({ sku: sellerSku, error }));
 
 /**
- * productCategory
+ * @typedef productCategory
  * Product Category Information
  * @param {string} ProductCategoryId - The string or numeric-string category identifier for the category
  * @param {string} ProductCategoryName - The string human readable description of the category

--- a/lib/list-financial-events.js
+++ b/lib/list-financial-events.js
@@ -1,8 +1,30 @@
-const { callEndpoint } = require('./callEndpoint');
+const { parseEndpoint2 } = require('./callEndpoint');
 const { forceArray } = require('./util/transformers');
 
 // TODO: probably needs to handle nextToken
 // TODO: write some tests to more completely test this function's output
+
+const inputParser = opt => ({
+    MaxResultsPerPage: opt.maxResultsPerPage || opt.MaxResultsPerPage,
+    AmazonOrderId: opt.amazonOrderId || opt.AmazonOrderId,
+    FinancialEventGroupId: opt.financialEventGroupId || opt.FinancialEventGroupId,
+    PostedAfter: opt.postedAfter || opt.PostedAfter,
+    PostedBefore: opt.postedBefore || opt.PostedBefore,
+});
+
+const outputParser = (out) => {
+    const res = out.FinancialEvents;
+    // TODO: all-in-all, this parser needs a lot of work.
+    // TODO: This call can return a *LOT* of differently named items, and it's difficult to figure out what needs to be forced
+    // to Array type.
+    try {
+        res.ShipmentEventList.ShipmentEvent.ShipmentItemList.ShipmentItem =
+            forceArray(res.ShipmentEventList.ShipmentEvent.ShipmentItemList.ShipmentItem);
+    } catch (err) {
+        //
+    }
+    return res;
+};
 
 /**
  * https://docs.developer.amazonservices.com/en_UK/finances/Finances_ListFinancialEvents.html
@@ -15,17 +37,6 @@ const { forceArray } = require('./util/transformers');
  * @param {Date} options.PostedBefore When to search for events prior to
  * @returns {object}
  */
-const listFinancialEvents = async (options) => {
-    const results = (await callEndpoint('ListFinancialEvents', options)).FinancialEvents;
-    // TODO: This call can return a *LOT* of differently named items, and it's difficult to figure out what needs to be forced
-    // to Array type.
-    try {
-        // force ShipmentItems to be an array
-        results.ShipmentEventList.ShipmentEvent.ShipmentItemList.ShipmentItem = forceArray(results.ShipmentEventList.ShipmentEvent.ShipmentItemList.ShipmentItem);
-    } catch (err) {
-        //
-    }
-    return results;
-};
+const listFinancialEvents = parseEndpoint2(outputParser, inputParser)('ListFinancialEvents');
 
 module.exports = { listFinancialEvents };

--- a/lib/list-inventory-supply.js
+++ b/lib/list-inventory-supply.js
@@ -1,4 +1,4 @@
-const { callEndpoint } = require('./callEndpoint');
+const { parseEndpoint2 } = require('./callEndpoint');
 
 /*
 [ { Condition: 'NewItem',
@@ -10,6 +10,17 @@ const { callEndpoint } = require('./callEndpoint');
     SellerSKU: 'ND-X5EF-Z0N1' } ]
 */
 
+const inputParser = opt => ({
+    SellerSkus: opt.sellerSkus || opt.SellerSkus,
+    QueryStartDateTime: opt.queryStartDateTime || opt.QueryStartDateTime,
+    ResponseGroup: opt.responseGroup || opt.ResponseGroup,
+    MarketplaceId: opt.marketplaceId || opt.MarketplaceId,
+});
+
+const outputParser = out => ({
+    nextToken: out.NextToken,
+    supplyList: out.InventorySupplyList ? out.InventorySupplyList.member : undefined,
+});
 
 /**
  * Return information about the availability of a seller's FBA inventory
@@ -22,9 +33,6 @@ const { callEndpoint } = require('./callEndpoint');
  *
  * @returns {{ nextToken: string, supplyList: object[] }}
  */
-const listInventorySupply = async (options) => {
-    const results = await callEndpoint('ListInventorySupply', options);
-    return { nextToken: results.NextToken, supplyList: results.InventorySupplyList.member };
-};
+const listInventorySupply = parseEndpoint2(outputParser, inputParser)('ListInventorySupply');
 
 module.exports = { listInventorySupply };

--- a/lib/list-matching-products.js
+++ b/lib/list-matching-products.js
@@ -1,5 +1,14 @@
 const { parseEndpoint2 } = require('./callEndpoint');
 const parseMatchingProduct = require('./parsers/matchingProduct');
+
+const inputParser = opt => ({
+    MarketplaceId: opt.marketplaceId || opt.MarketplaceId,
+    Query: opt.query || opt.Query,
+    QueryContextId: opt.queryContextId || opt.QueryContextId,
+});
+
+const outputParser = out => parseMatchingProduct(out)[0].results;
+
 /**
  * Return a list of products and their attributes, based on a text query and contextId.
  *
@@ -9,19 +18,8 @@ const parseMatchingProduct = require('./parsers/matchingProduct');
  * @param {string} [options.queryContextId] - context in which to limit search. Not specified will mean "search everywhere". See https://docs.developer.amazonservices.com/en_UK/products/Products_QueryContextIDs.html
  * @returns {Product[]} - Array of product information
  */
-const listMatchingProducts = async (options, callOpt) => {
-    const parsedOpt = {
-        MarketplaceId: options.marketplaceId,
-        Query: options.query,
-        QueryContextId: options.queryContextId,
-    };
-    const results = await parseEndpoint2(parseMatchingProduct)('ListMatchingProducts')(parsedOpt, callOpt);
-    // TODO: should put the results of a GetMatchingProductForId call and a ListMatchingProducts
-    // call side by side with each other, so we can figure out exactly where they differ. As is,
-    // this parser is perfectly capable of handling the parsing, but the output comes out
-    // unexpectedly buried a level deep in an array.
-    return results[0].results;
-};
+
+const listMatchingProducts = parseEndpoint2(outputParser, inputParser)('ListMatchingProducts');
 
 module.exports = {
     listMatchingProducts,

--- a/lib/list-order-items.js
+++ b/lib/list-order-items.js
@@ -38,10 +38,9 @@ const parseOrderItems = require('./parsers/orderItems');
  * @param {string} AmazonOrderId - 3-7-7 Amazon Order ID formatted string
  * @returns {OrderItemList}
  */
-const listOrderItems = async (AmazonOrderId) => {
-    const results = await parseEndpoint2(parseOrderItems)('ListOrderItems')({ AmazonOrderId });
-    return results;
-};
+
+const listOrderItems =
+    parseEndpoint2(parseOrderItems, AmazonOrderId => ({ AmazonOrderId }))('ListOrderItems');
 
 module.exports = {
     listOrderItems,

--- a/lib/list-orders.js
+++ b/lib/list-orders.js
@@ -1,4 +1,4 @@
-const { callEndpoint } = require('./callEndpoint');
+const { parseEndpoint2 } = require('./callEndpoint');
 
 // returns
 /*
@@ -36,9 +36,7 @@ const { callEndpoint } = require('./callEndpoint');
  * @param {string} [options.TFMShipmentStatus] See MWS doc page
  * @returns {object}
  */
-const listOrders = async (options) => {
-    const results = await callEndpoint('ListOrders', options);
-    return results.Orders.Order;
-};
+
+const listOrders = parseEndpoint2(out => out.Orders.Order)('ListOrders');
 
 module.exports = { listOrders };

--- a/lib/reports.js
+++ b/lib/reports.js
@@ -17,7 +17,7 @@ const errors = require('./errors');
  */
 const writeFile = promisify(fs.writeFile);
 
-const { callEndpoint } = require('./callEndpoint');
+const { parseEndpoint2 } = require('./callEndpoint');
 const sleep = require('./util/sleep');
 
 /**
@@ -45,10 +45,7 @@ const sleep = require('./util/sleep');
  * @param {string[]} [MarketplaceId] Array of marketplace IDs to generate reports covering
  * @returns {ReportRequestInfo}
  */
-const requestReport = async (options) => {
-    const result = await callEndpoint('RequestReport', options);
-    return result.ReportRequestInfo;
-};
+const requestReport = parseEndpoint2(out => out.ReportRequestInfo)('RequestReport');
 
 // interesting note: there are tons of reports returned by this API,
 // apparently Amazon auto pulls reports, and many reports pulled in the Seller Central
@@ -69,6 +66,17 @@ const requestReport = async (options) => {
  * @param {string} GeneratedReportId Identifier to use with getReport to retrieve the report
  */
 
+// TODO: write a test to make sure nextToken is here correctly?
+const reportRequestListParser = (out) => {
+    let nextToken;
+    try {
+        nextToken = out.GetReportRequestListResponse.GetReportRequestListResult.NextToken;
+    } catch (err) {
+        //
+    }
+    return { nextToken, reportRequestList: out.ReportRequestInfo };
+};
+
 /**
  * Returns a list of report requests that you can use to get the ReportRequestId for a report
  * After calling requestReport, you should call this function occasionally to see if/when the report
@@ -84,12 +92,7 @@ const requestReport = async (options) => {
  * @param {Date} [RequestedToDate=Now] Newest date to search for
  * @returns {GetReportRequestListResult[]}
  */
-// TODO: make sure we get NextToken out of there and into the main data structure somewhere
-const getReportRequestList = async (options = {}) => {
-    const result = await callEndpoint('GetReportRequestList', options);
-    // NextToken is under result.GetReportRequestListResponse.GetReportRequestListResult
-    return result.ReportRequestInfo;
-};
+const getReportRequestList = parseEndpoint2(reportRequestListParser)('GetReportRequestList');
 
 /**
  * Returns the contents of a report
@@ -98,45 +101,31 @@ const getReportRequestList = async (options = {}) => {
  * @param {string} options.ReportId Report number from @see {@link GetReportList} or GeneratedReportId from @see {@link GetReportRequestListResult}
  * @return {Array|object} Contents of the report to return (format may vary WIDELY between different reports generated, see [ReportType](https://docs.developer.amazonservices.com/en_US/reports/Reports_ReportType.html))
  */
-const getReport = async (options) => {
-    const result = await callEndpoint('GetReport', options);
-    return result;
+const getReport = parseEndpoint2(x => x)('GetReport');
+
+const getReportListParser = (out) => {
+    try {
+        const ret = {
+            result: out.ReportInfo,
+            nextToken: out.HasNext && out.NextToken,
+        };
+        return ret;
+    } catch (err) {
+        return out;
+    }
 };
 
 /**
  * TODO: write documentation for getReportList
  */
-const getReportList = async (options = {}) => {
-    const result = await callEndpoint('GetReportList', options);
-    // NextToken should be in result.GetReportListResponse.GetReportListResult
-    try {
-        const ret = {
-            result: result.ReportInfo,
-            nextToken: result.HasNext && result.NextToken,
-        };
-        return ret;
-    } catch (err) {
-        return result;
-    }
-};
+const getReportList = parseEndpoint2(getReportListParser)('GetReportList');
 
 /**
  * TODO: write documentation for getReportListByNextToken
  * (or just roll getReportList and getReportListByNextToken into the same wrapper)
  * (that wrapper might be getReportListAll, and just rename it)
  */
-const getReportListByNextToken = async (options) => {
-    const result = await callEndpoint('GetReportListByNextToken', options);
-    try {
-        const ret = {
-            result: result.ReportInfo,
-            nextToken: result.HasNext && result.NextToken,
-        };
-        return ret;
-    } catch (err) {
-        return result;
-    }
-};
+const getReportListByNextToken = parseEndpoint2(getReportListParser)('GetReportListByNextToken');
 
 /**
  * TODO: write documentation for getReportListAll (or see comment on getReportListByNextToken)
@@ -201,7 +190,7 @@ const requestAndDownloadReport = async (ReportType, file, reportParams = {}) => 
             const report = await getReportRequestList({
                 ReportRequestIdList: [reportRequestId],
             });
-            switch (report.ReportProcessingStatus) {
+            switch (report.reportRequestList.ReportProcessingStatus) {
                 case '_IN_PROGRESS_': // fallthrough intentional
                 case '_SUBMITTED_': // fallthrough intentional
                     console.log(`-- retrying report ${reportRequestId} in 45 sec`);
@@ -211,7 +200,7 @@ const requestAndDownloadReport = async (ReportType, file, reportParams = {}) => 
                     console.log(`-- cancelled: ${reportRequestId}`, report);
                     return { cancelled: true };
                 case '_DONE_':
-                    return report;
+                    return report.reportRequestList;
                 case '_DONE_NO_DATA_':
                     return null;
                 default:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "Apache",
   "dependencies": {
     "es6-error": "^4.1.1",
-    "mws-simple": "github:ericblade/mws-simple#2.2.3"
+    "mws-simple": "github:ericblade/mws-simple#2.3.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
- parseEndpoint2 is turning out to be a much better idea than the original
  :-)
- added an input parser function call to parseEndpoint2
- switch almost all of the wrapper functions to use parseEndpoint2 instead
  of parseEndpoint or callEndpoint
- getReportRequestList got it's TODO to add a nextToken to it.
  it's output now is { nextToken, reportRequestList } instead of being
  the reportRequestList alone