### PR TITLE
add SellerId params to reports endpoints

### DIFF
--- a/lib/endpoints/reports.js
+++ b/lib/endpoints/reports.js
@@ -136,6 +136,10 @@ const newEndpointList = {
                 type: 'xs:string',
                 required: true,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             NextToken: {
@@ -149,10 +153,6 @@ const newEndpointList = {
             ReportRequestInfo: {
                 type: 'ReportRequestInfo',
                 required: true,
-            },
-            SellerId: {
-                type: 'xs:string',
-                required: false,
             },
         },
     },

--- a/lib/endpoints/reports.js
+++ b/lib/endpoints/reports.js
@@ -54,6 +54,10 @@ const newEndpointList = {
                 list: 'MarketplaceIdList.Id',
                 required: false, // TODO: only available in NA and EU regions
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             ReportRequestInfo: {
@@ -102,6 +106,10 @@ const newEndpointList = {
                 type: 'xs:dateTime',
                 required: false,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             NextToken: {
@@ -142,6 +150,10 @@ const newEndpointList = {
                 type: 'ReportRequestInfo',
                 required: true,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
     },
     GetReportRequestCount: {
@@ -166,6 +178,10 @@ const newEndpointList = {
             },
             RequestedToDate: {
                 type: 'xs:dateTime',
+                required: false,
+            },
+            SellerId: {
+                type: 'xs:string',
                 required: false,
             },
         },
@@ -204,6 +220,10 @@ const newEndpointList = {
             },
             RequestedToDate: {
                 type: 'xs:dateTime',
+                required: false,
+            },
+            SellerId: {
+                type: 'xs:string',
                 required: false,
             },
         },
@@ -256,6 +276,10 @@ const newEndpointList = {
                 type: 'xs:dateTime',
                 required: false,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             NextToken: {
@@ -281,6 +305,10 @@ const newEndpointList = {
             NextToken: {
                 type: 'xs:string',
                 required: true,
+            },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
             },
         },
         returns: {
@@ -326,6 +354,10 @@ const newEndpointList = {
                 type: 'xs:dateTime',
                 required: false,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             Count: { // Return types are not documented on this page! Assuming from example.
@@ -343,6 +375,10 @@ const newEndpointList = {
             ReportId: {
                 type: 'xs:string',
                 required: true,
+            },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
             },
         },
         returns: {
@@ -372,6 +408,10 @@ const newEndpointList = {
                 type: 'xs:dateTime',
                 required: false,
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             Count: {
@@ -394,6 +434,10 @@ const newEndpointList = {
                 type: 'xs:string',
                 required: false,
                 values: constants.SCHEDULED_REPORT_TYPES,
+            },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
             },
         },
         returns: {
@@ -452,6 +496,10 @@ const newEndpointList = {
                 ],
                 list: 'ReportTypeList.Type',
             },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
+            },
         },
         returns: {
             Count: {
@@ -474,6 +522,10 @@ const newEndpointList = {
             Acknowledged: {
                 type: 'xs:boolean',
                 required: true,
+            },
+            SellerId: {
+                type: 'xs:string',
+                required: false,
             },
         },
         returns: {


### PR DESCRIPTION
Hello @ericblade!

Thank you so much for all of your work!

I'm using it with different merchantId for each calls and I needed to be able to fetch reports without setting merchantId in the init. The validator threw an error if I added the SellerId params as I do usually.

I added the parameter in all reports endpoints and have the following questions:

- Is this the good way to solve this issue?
- Should I add tests for this? If so, where?

Best regards!

Conrad
